### PR TITLE
Fix restated start date calculation of first month on leap years

### DIFF
--- a/__tests__/data/nrf_2018.ts
+++ b/__tests__/data/nrf_2018.ts
@@ -60,3 +60,11 @@ export const nrf2018 = [
     end: '2019-02-02',
   },
 ]
+
+export const nrf2017Restated = [
+  {
+    monthOfYear: 0,
+    start: '2017-02-05',
+    end: '2017-03-04',
+  },
+]

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/types'
 import { nrfYears } from './data/nrf_years'
 import { lastDayBeforeEOMYears } from './data/last_day_before_eom_years'
-import { nrf2018 } from './data/nrf_2018'
+import { nrf2018, nrf2017Restated } from './data/nrf_2018'
 import { firstBow } from './data/first_bow'
 import moment from 'moment'
 
@@ -46,6 +46,19 @@ describe('RetailCalendar', () => {
           moment(nrfMonth.end).endOf('day').toDate().getTime(),
         )
       }
+    })
+
+    it('returns start date and end of first month on leap years', () => {
+      const calendar = new RetailCalendarFactory(NRFCalendarOptions, 2017)
+      const monthIndex = 0
+      const month = calendar.months[monthIndex]
+      const nrfMonth = nrf2017Restated[monthIndex]
+      expect(month.gregorianStartDate.getTime()).toEqual(
+        moment(nrfMonth.start).startOf('day').toDate().getTime(),
+      )
+      expect(month.gregorianEndDate.getTime()).toEqual(
+        moment(nrfMonth.end).endOf('day').toDate().getTime(),
+      )
     })
 
     it('returns weeks with corect month', () => {

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -48,15 +48,19 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
 
     for (const numberOfWeeks of this.getWeekDistribution()) {
       const quarterOfYear = Math.ceil(index / 3)
-      const weeks = this.weeks.filter((week) => week.monthOfYear === index)
-      const monthStart = moment(weeks[0].gregorianStartDate)
-      const monthEnd = moment(weeks[weeks.length - 1].gregorianEndDate)
+      const weeksOfMonth = this.weeks.filter(
+        (week) => week.monthOfYear === index,
+      )
+      const monthStart = moment(weeksOfMonth[0].gregorianStartDate)
+      const monthEnd = moment(
+        weeksOfMonth[weeksOfMonth.length - 1].gregorianEndDate,
+      )
       months.push(
         new CalendarMonth(
           index,
           quarterOfYear,
           numberOfWeeks,
-          weeks,
+          weeksOfMonth,
           monthStart.toDate(),
           monthEnd.toDate(),
         ),

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -45,16 +45,12 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
   generateMonths(): RetailCalendarMonth[] {
     const months = []
     let index = 1
-    const currentStart = this.firstDayOfYear
 
     for (const numberOfWeeks of this.getWeekDistribution()) {
       const quarterOfYear = Math.ceil(index / 3)
       const weeks = this.weeks.filter((week) => week.monthOfYear === index)
-      const monthStart = moment(currentStart)
-      const monthEnd = moment(monthStart)
-        .add(numberOfWeeks, 'week')
-        .subtract(1, 'day')
-        .endOf('day')
+      const monthStart = moment(weeks[0].gregorianStartDate)
+      const monthEnd = moment(weeks[weeks.length - 1].gregorianEndDate)
       months.push(
         new CalendarMonth(
           index,
@@ -66,7 +62,6 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
         ),
       )
       index += 1
-      currentStart.add(numberOfWeeks, 'week')
     }
 
     return months


### PR DESCRIPTION
Issue: https://app.asana.com/0/1170912128710275/1187761336297937/f

There is a bug in `gregorianStartDate` calculation of the first month. When calendar year is a leap year and the 53rd week is restated, the `gregorianStartDate` of the first month is the same as the `gregorianStartDate` of the year. However, this is wrong. The first week of the year isn't included in any months.

To fix this bug, start and end date calculation for months are simplified. Now a month's start date is always the start date of its first week. A month's end date is always the end of its last week.