### PR TITLE
Fix quarterOfYear calculation

### DIFF
--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -286,5 +286,25 @@ describe('RetailCalendar', () => {
         expect(calendar.months[index].monthOfYear).toBe(index)
       }
     })
+
+    it('returns correct quarterOfYear value for each month', () => {
+      const calendar = new RetailCalendarFactory({...NRFCalendarOptions, beginningMonthIndex: 0}, 2018)
+      const months= calendar.months
+      expect(months[0].quarterOfYear).toBe(1)
+      expect(months[1].quarterOfYear).toBe(1)
+      expect(months[2].quarterOfYear).toBe(1)
+
+      expect(months[3].quarterOfYear).toBe(2)
+      expect(months[4].quarterOfYear).toBe(2)
+      expect(months[5].quarterOfYear).toBe(2)
+
+      expect(months[6].quarterOfYear).toBe(3)
+      expect(months[7].quarterOfYear).toBe(3)
+      expect(months[8].quarterOfYear).toBe(3)
+
+      expect(months[9].quarterOfYear).toBe(4)
+      expect(months[10].quarterOfYear).toBe(4)
+      expect(months[11].quarterOfYear).toBe(4)
+    })
   })
 })

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -44,10 +44,11 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
 
   generateMonths(): RetailCalendarMonth[] {
     const months = []
-    let index = this.getBeginningOfMonthIndex()
+    const beginningIndex = this.getBeginningOfMonthIndex()
+    let index = beginningIndex
 
     for (const numberOfWeeks of this.getWeekDistribution()) {
-      const quarterOfYear = Math.ceil(index / 3)
+      const quarterOfYear = Math.floor((index - beginningIndex) / 3) + 1
       const weeksOfMonth = this.weeks.filter(
         (week) => week.monthOfYear === index,
       )


### PR DESCRIPTION
When beginningMonthIndex option was a non 1 value, quarterOfYear calculation was broken.