### PR TITLE
Introduce last day before EOM except leap year strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ calendar.weeks[0].gregorianEndDate // Date
 ### 53 week years
 
 Based on given configuration, a year may contain 53 weeks.
-This complicates comparing months to previous year. This case is handled specially based on given `restated` option. Number
+This complicates comparing months to previous year. This case is handled specially based on given `restated` option.
 
 If `restated` is `true`
 
@@ -152,6 +152,8 @@ See [4-4-5 Calendar](https://en.wikipedia.org/wiki/4%E2%80%934%E2%80%935_calenda
 
 - WeekCalculation.LastDayBeforeEOM: Use the last end of retail week, before the end of last gregorian month in the year.
 
+- WeekCalculation.LastDayBeforeEomExceptLeapYear: Use the last end of retail week, before the end of last gregorian month in the year. If next year is leap year (has 53 weeks), make this year leap year by moving end of this year by 1 week forward.
+
 - WeekCalculation.FirstBOWOfFirstMonth: Use the first, beginning of week day, of the start month as the start day of year.
 
 #### LastMonthOfYear
@@ -174,4 +176,4 @@ Specifies how many weeks each month has in a quarter.
 `boolean`. If true, in leap years, first week is not included in any month.
 Otherwise, in leap years, last week is not included in any month.
 
-Has not effect on 52 week years.
+Has no effect on 52 week years.

--- a/__tests__/data/last_day_before_eom_except_leap_year.ts
+++ b/__tests__/data/last_day_before_eom_except_leap_year.ts
@@ -1,0 +1,88 @@
+export const lastDayBeforeEomExceptLeapYear = [
+  {
+    year: 2021,
+    months: [
+      {
+        monthOfYear: 0,
+        start: '2020-12-27',
+        end: '2021-01-23',
+      },
+      {
+        monthOfYear: 1,
+        start: '2021-01-24',
+        end: '2021-02-20',
+      },
+      {
+        monthOfYear: 2,
+        start: '2021-02-21',
+        end: '2021-03-27',
+      },
+      {
+        monthOfYear: 3,
+        start: '2021-03-28',
+        end: '2021-04-24',
+      },
+      {
+        monthOfYear: 4,
+        start: '2021-04-25',
+        end: '2021-05-22',
+      },
+      {
+        monthOfYear: 5,
+        start: '2021-05-23',
+        end: '2021-06-26',
+      },
+      {
+        monthOfYear: 6,
+        start: '2021-06-27',
+        end: '2021-07-24',
+      },
+      {
+        monthOfYear: 7,
+        start: '2021-07-25',
+        end: '2021-08-21',
+      },
+      {
+        monthOfYear: 8,
+        start: '2021-08-22',
+        end: '2021-09-25',
+      },
+      {
+        monthOfYear: 9,
+        start: '2021-09-26',
+        end: '2021-10-23',
+      },
+      {
+        monthOfYear: 10,
+        start: '2021-10-24',
+        end: '2021-11-20',
+      },
+      {
+        monthOfYear: 11,
+        start: '2021-11-21',
+        end: '2021-12-25',
+      },
+    ],
+    leapWeek: {
+      start: '2021-12-26',
+      end: '2022-01-01'
+    }
+      
+    
+  },
+  {
+    year: 2020,
+    months: [
+      {
+        monthOfYear: 0,
+        start: '2019-12-29',
+        end: '2020-01-25',
+      },
+      {
+        monthOfYear: 11,
+        start: '2020-11-22',
+        end: '2020-12-26',
+      },
+    ],
+  },
+]

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -1,3 +1,5 @@
+import { LastDayBeforeEOMExceptLeapYearStrategy } from '../src/last_day_before_eom_except_leap_year';
+import { LastDayBeforeEOMStrategy } from './../src/last_day_before_eom';
 import { FirstBOWOfFirstMonth } from '../src/first_bow_of_first_month'
 import { RetailCalendarFactory } from '../src/retail_calendar'
 import {
@@ -13,6 +15,9 @@ import { lastDayBeforeEOMYears } from './data/last_day_before_eom_years'
 import { nrf2018, nrf2017Restated } from './data/nrf_2018'
 import { firstBow } from './data/first_bow'
 import moment from 'moment'
+import { lastDayBeforeEomExceptLeapYear } from './data/last_day_before_eom_except_leap_year';
+
+const DayComparisonFormat = 'YYYY-MM-DD'
 
 describe('RetailCalendar', () => {
   describe('given NRF calendar options', () => {
@@ -305,6 +310,39 @@ describe('RetailCalendar', () => {
       expect(months[9].quarterOfYear).toBe(4)
       expect(months[10].quarterOfYear).toBe(4)
       expect(months[11].quarterOfYear).toBe(4)
+    })
+  })
+
+  describe('given "last day nearest end of month except restated" week calculation method', ()=> {
+
+    it('it moves 53rd week to previous year ', ()=> {
+      const options = {
+        weekGrouping: WeekGrouping.Group445,
+        lastDayOfWeek: LastDayOfWeek.Saturday,
+        lastMonthOfYear: LastMonthOfYear.December,
+        weekCalculation: WeekCalculation.LastDayBeforeEomExceptLeapYear,
+        restated: false,
+      }
+    
+      for (const yearData of lastDayBeforeEomExceptLeapYear) {
+        const calendar = new RetailCalendarFactory(options, yearData.year)
+        for (const month of yearData.months) {
+          const calendarMonth = calendar.months[month.monthOfYear]
+          expect(moment(calendarMonth.gregorianStartDate).format(DayComparisonFormat))
+            .toEqual(month.start,)
+          expect(moment(calendarMonth.gregorianEndDate).format(DayComparisonFormat)).toEqual(
+            month.end,
+          )
+        }
+        if(yearData.leapWeek) {
+          const leapWeek = calendar.weeks[52]
+          expect(moment(leapWeek.gregorianStartDate).format(DayComparisonFormat))
+            .toEqual(yearData.leapWeek.start)
+          expect(moment(leapWeek.gregorianEndDate).format(DayComparisonFormat))
+            .toEqual(yearData.leapWeek.end)
+        }
+      }
+      
     })
   })
 })

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -329,9 +329,9 @@ describe('RetailCalendar', () => {
         for (const month of yearData.months) {
           const calendarMonth = calendar.months[month.monthOfYear]
           expect(moment(calendarMonth.gregorianStartDate).format(DayComparisonFormat))
-            .toEqual(month.start,)
+            .toEqual(month.start)
           expect(moment(calendarMonth.gregorianEndDate).format(DayComparisonFormat)).toEqual(
-            month.end,
+            month.end
           )
         }
         if(yearData.leapWeek) {

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -315,7 +315,7 @@ describe('RetailCalendar', () => {
 
   describe('given "last day nearest end of month except restated" week calculation method', ()=> {
 
-    it('it moves 53rd week to previous year ', ()=> {
+    it('it moves 53rd week to previous year', ()=> {
       const options = {
         weekGrouping: WeekGrouping.Group445,
         lastDayOfWeek: LastDayOfWeek.Saturday,

--- a/src/last_day_before_eom_except_leap_year.ts
+++ b/src/last_day_before_eom_except_leap_year.ts
@@ -1,0 +1,22 @@
+import { LastDayBeforeEOMStrategy } from './last_day_before_eom';
+import moment from 'moment'
+import { LastDayStrategy } from './types'
+
+export class LastDayBeforeEOMExceptLeapYearStrategy implements LastDayStrategy {
+  getLastDayForGregorianLastDay(
+    lastDayOfGregorianYear: moment.Moment,
+    lastDayOfIsoWeek: number,
+  ): moment.Moment {
+    const lastDayOfNextGregorianYear = moment(lastDayOfGregorianYear).add(1, 'day').endOf('year')
+    const lastDayOfThisYear = new LastDayBeforeEOMStrategy()
+      .getLastDayForGregorianLastDay(lastDayOfGregorianYear, lastDayOfIsoWeek)
+    const lastDayOfNextYear = new LastDayBeforeEOMStrategy()
+      .getLastDayForGregorianLastDay(lastDayOfNextGregorianYear, lastDayOfIsoWeek)
+
+    if(lastDayOfNextYear.diff(lastDayOfThisYear, 'week') === 53) {
+      return moment(lastDayOfThisYear).add(1, 'week')
+    }
+
+    return lastDayOfThisYear
+  }
+}

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -16,6 +16,7 @@ import { CalendarWeek } from './calendar_week'
 import { LastDayBeforeEOMStrategy } from './last_day_before_eom'
 import { LastDayNearestEOMStrategy } from './last_day_nearest_eom'
 import { FirstBOWOfFirstMonth } from './first_bow_of_first_month'
+import { LastDayBeforeEOMExceptLeapYearStrategy } from './last_day_before_eom_except_leap_year'
 
 export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
   implements RetailCalendar {
@@ -191,6 +192,8 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     switch (weekCalculation) {
       case WeekCalculation.LastDayBeforeEOM:
         return new LastDayBeforeEOMStrategy()
+      case WeekCalculation.LastDayBeforeEomExceptLeapYear:
+        return new LastDayBeforeEOMExceptLeapYearStrategy()
       case WeekCalculation.LastDayNearestEOM:
         return new LastDayNearestEOMStrategy()
       case WeekCalculation.FirstBOWOfFirstMonth:

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export enum LastMonthOfYear {
 }
 export enum WeekCalculation {
   LastDayBeforeEOM,
+  LastDayBeforeEomExceptLeapYear,
   LastDayNearestEOM,
   FirstBOWOfFirstMonth,
 }


### PR DESCRIPTION
Adds a new week calculation strategy. The same as LastDayBeforeEOM but moves leap year back by one year.