### PR TITLE
User can specify different leap year strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const calendar = new RetailCalendarFactory(
     weekGrouping: WeekGrouping.Group454,
     lastDayOfWeek: LastDayOfWeek.Saturday,
     lastMonthOfYear: LastMonthOfYear.January,
-    leapYearStrategy: LeapYearStrategy.DropFirstWeek
+    leapYearStrategy: LeapYearStrategy.DropFirstWeek // deprecated: restated: false
   },
   2017,
 )
@@ -102,9 +102,11 @@ calendar.weeks[0].gregorianEndDate // Date
 ### 53 week years
 
 Based on given configuration, a year may contain 53 weeks.
-This complicates comparing months to previous year. This case is handled specially based on given [LeapYearStrategy](#LeapYearStrategy) option.
+This complicates comparing months to previous year. This case is handled specially based on the given [LeapYearStrategy](#LeapYearStrategy) option.
 
-If `leapYearStrategy` is `LeapYearStrategy.Restated`
+#### Restated
+
+If `leapYearStrategy` is `LeapYearStrategy.Restated` 
 
 FIRST week of year is "dropped". It doesn't belong the any month.
 
@@ -121,6 +123,10 @@ calendar.weeks[0].monthOfYear // -1
 calendar.months[0].weeks[0].weekOfYear // 0
 ```
 
+⚠ *previous versions of this library used the `restated: true` option to specify a Restated leap year strategy. This still works but is deprecated!* ⚠
+
+#### Drop First Week
+
 If `leapYearStrategy` is `LeapYearStrategy.DropFirstWeek`
 
 LAST week of year is "dropped".
@@ -135,6 +141,9 @@ calendar.weeks[52].monthOfYear // -1
 // First month starts from 1st week
 calendar.months[0].weeks[0].weekOfYear // 0
 ```
+⚠ *previous versions of this library used the `restated: false` option to specify a "Drop First Week" leap year strategy. This still works but is deprecated!* ⚠
+
+#### Add to Penultimate Month
 
 If `leapYearStrategy` is `LeapYearStrategy.AddToPenultimateMonth`
 
@@ -191,3 +200,10 @@ If the year is a leap year (in the context of a retail calendar that means it ha
 * And `LeapYearStrategy.AddToPenultimateMonth` is selected, the extra week is added to the 11th month
 
 This option has no effect on 52 week years.
+
+### restated [Deprecated]
+⚠ *This option has been superseded by [LeapYearStrategy](#LeapYearStrategy)* ⚠
+
+`boolean`. If true, in leap years, first week is not included in any month. Otherwise, in leap years, last week is not included in any month.
+
+Has no effect on 52 week years.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ calendar.weeks[52].monthOfYear // -1
 calendar.months[0].weeks[0].weekOfYear // 0
 ```
 
+If `leapYearStrategy` is `LeapYearStrategy.AddToPenultimateMonth`
+
+extra week is "added" to the ELEVENTH month
+
+```javascript
+// AddToPenultimateMonth calendar example for 445 Calendar.
+// 11th Month has 5 weeks instead of 4
+calendar.months[10].weeks.length //5
+```
 ### Options
 
 #### LastDayOfWeek
@@ -179,5 +188,6 @@ If the year is a leap year (in the context of a retail calendar that means it ha
 
 * And `LeapYearStrategy.Restated` is selected, the first week is not included in any month.
 * And `LeapYearStrategy.DropFirstWeek` is selected, the last week is not included in any month.
+* And `LeapYearStrategy.AddToPenultimateMonth` is selected, the extra week is added to the 11th month
 
 This option has no effect on 52 week years.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const calendar = new RetailCalendarFactory(
     weekGrouping: WeekGrouping.Group454,
     lastDayOfWeek: LastDayOfWeek.Saturday,
     lastMonthOfYear: LastMonthOfYear.January,
-    restated: false,
+    leapYearStrategy: LeapYearStrategy.DropFirstWeek
   },
   2017,
 )
@@ -102,9 +102,9 @@ calendar.weeks[0].gregorianEndDate // Date
 ### 53 week years
 
 Based on given configuration, a year may contain 53 weeks.
-This complicates comparing months to previous year. This case is handled specially based on given `restated` option.
+This complicates comparing months to previous year. This case is handled specially based on given [LeapYearStrategy](#LeapYearStrategy) option.
 
-If `restated` is `true`
+If `leapYearStrategy` is `LeapYearStrategy.Restated`
 
 FIRST week of year is "dropped". It doesn't belong the any month.
 
@@ -121,7 +121,7 @@ calendar.weeks[0].monthOfYear // -1
 calendar.months[0].weeks[0].weekOfYear // 0
 ```
 
-If `restated` is `false`
+If `leapYearStrategy` is `LeapYearStrategy.DropFirstWeek`
 
 LAST week of year is "dropped".
 
@@ -171,9 +171,13 @@ Specifies how many weeks each month has in a quarter.
 - `WeekGrouping.Group544`: 1st month has 5 weeks, 2nd has 4, 3rd has 4. Repeats for each quarter.
 - `WeekGrouping.Group445`: 1st month has 4 weeks, 2nd has 4, 3rd has 5. Repeats for each quarter.
 
-#### restated
+#### LeapYearStrategy
 
-`boolean`. If true, in leap years, first week is not included in any month.
-Otherwise, in leap years, last week is not included in any month.
+`enum`
 
-Has no effect on 52 week years.
+If the year is a leap year (in the context of a retail calendar that means it has 53 weeks)
+
+* And `LeapYearStrategy.Restated` is selected, the first week is not included in any month.
+* And `LeapYearStrategy.DropFirstWeek` is selected, the last week is not included in any month.
+
+This option has no effect on 52 week years.

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -22,6 +22,71 @@ import { lastDayBeforeEomExceptLeapYear } from './data/last_day_before_eom_excep
 const DayComparisonFormat = 'YYYY-MM-DD'
 
 describe('RetailCalendar', () => {
+  describe("leap year strategy options", () => {
+
+    describe('when neither restated nor leapYearStrategy is provided', () => {
+      it('throws an error', () => {
+        expect(() => {
+          new RetailCalendarFactory({
+            weekGrouping: WeekGrouping.Group454,
+            lastDayOfWeek: LastDayOfWeek.Saturday,
+            lastMonthOfYear: LastMonthOfYear.January,
+            weekCalculation: WeekCalculation.LastDayNearestEOM,
+          }, 2018)
+        }).toThrowError(/leapYearStrategy or restated/)
+      })
+    })
+
+    describe("when restated is provided and its true", () => {
+      it("emits a warning", () => {
+        jest.spyOn(console, 'warn').mockImplementation()
+        const retailCalendar = new RetailCalendarFactory({
+          weekGrouping: WeekGrouping.Group454,
+          lastDayOfWeek: LastDayOfWeek.Saturday,
+          lastMonthOfYear: LastMonthOfYear.January,
+          weekCalculation: WeekCalculation.LastDayNearestEOM, 
+          restated: true
+        }, 2017)
+
+        expect(retailCalendar.leapYearStrategy).toBe(LeapYearStrategy.Restated)
+        expect(console.warn).toHaveBeenCalledWith("restated option is deprecated. Please use leapYearStrategy instead")
+      })
+    })
+
+    describe("when restated is provided and its false", () => {
+      it("emits a warning", () => {
+        jest.spyOn(console, 'warn').mockImplementation()
+        const retailCalendar = new RetailCalendarFactory({
+          weekGrouping: WeekGrouping.Group454,
+          lastDayOfWeek: LastDayOfWeek.Saturday,
+          lastMonthOfYear: LastMonthOfYear.January,
+          weekCalculation: WeekCalculation.LastDayNearestEOM,
+          restated: false
+        }, 2017)
+
+        expect(retailCalendar.leapYearStrategy).toBe(LeapYearStrategy.DropFirstWeek)
+        expect(console.warn).toHaveBeenCalledWith("restated option is deprecated. Please use leapYearStrategy instead")
+      })
+    })
+
+    describe("when restated and leapYearStrategy are provided", () => {
+      it('throws an erorr', () => {
+        expect(() => {
+          jest.spyOn(console, 'warn').mockImplementation()
+          const retailCalendar = new RetailCalendarFactory({
+            weekGrouping: WeekGrouping.Group454,
+            lastDayOfWeek: LastDayOfWeek.Saturday,
+            lastMonthOfYear: LastMonthOfYear.January,
+            weekCalculation: WeekCalculation.LastDayNearestEOM,
+            leapYearStrategy: LeapYearStrategy.Restated,
+            restated: false
+          }, 2017)
+        }).toThrowError(/Only one of leapYearStrategy or restated options can be given/)
+      })
+
+    })
+  })
+
   describe('given NRF calendar options', () => {
     it('numberOfWeeks calculates properly for each year', () => {
       for (const { year, numberOfWeeks } of nrfYears) {

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -9,6 +9,7 @@ import {
   LastMonthOfYear,
   WeekCalculation,
   NRFCalendarOptions,
+  LeapYearStrategy,
 } from '../src/types'
 import { nrfYears } from './data/nrf_years'
 import { lastDayBeforeEOMYears } from './data/last_day_before_eom_years'
@@ -154,7 +155,7 @@ describe('RetailCalendar', () => {
       describe('when not restated', () => {
         it('does not assign any months to last week', () => {
           const calendar = new RetailCalendarFactory(
-            { ...NRFCalendarOptions, restated: false },
+            { ...NRFCalendarOptions, leapYearStrategy: LeapYearStrategy.DropFirstWeek },
             2017,
           )
           const lastWeek = calendar.weeks[52]
@@ -180,7 +181,7 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.August,
         weekCalculation: WeekCalculation.LastDayBeforeEOM,
-        restated: false,
+        leapYearStrategy: LeapYearStrategy.DropFirstWeek
       }
 
       for (const { year, numberOfWeeks } of lastDayBeforeEOMYears) {
@@ -196,7 +197,7 @@ describe('RetailCalendar', () => {
           lastDayOfWeek: LastDayOfWeek.Saturday,
           lastMonthOfYear: LastMonthOfYear.August,
           weekCalculation: WeekCalculation.LastDayBeforeEOM,
-          restated: false,
+          leapYearStrategy: LeapYearStrategy.DropFirstWeek
         }
         const calendar = new RetailCalendarFactory(calendarOptions, 2015)
         const expectedMonthLenthsInWeeks = [5, 4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 4]
@@ -214,7 +215,7 @@ describe('RetailCalendar', () => {
           lastDayOfWeek: LastDayOfWeek.Saturday,
           lastMonthOfYear: LastMonthOfYear.August,
           weekCalculation: WeekCalculation.LastDayBeforeEOM,
-          restated: false,
+          leapYearStrategy: LeapYearStrategy.DropFirstWeek
         }
         const calendar = new RetailCalendarFactory(calendarOptions, 2015)
         const expectedMonthLenthsInWeeks = [4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 4, 5]
@@ -232,7 +233,7 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.December,
         weekCalculation: WeekCalculation.LastDayNearestEOM,
-        restated: true,
+        leapYearStrategy: LeapYearStrategy.Restated
       }
       const calendar = new RetailCalendarFactory(options, 2019)
       expect(calendar.months[11].gregorianStartDate.getFullYear()).toBe(2019)
@@ -246,7 +247,7 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.December,
         weekCalculation: WeekCalculation.FirstBOWOfFirstMonth,
-        restated: true,
+        leapYearStrategy: LeapYearStrategy.Restated
       }
 
       for (const yearData of firstBow) {
@@ -321,7 +322,7 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.December,
         weekCalculation: WeekCalculation.LastDayBeforeEomExceptLeapYear,
-        restated: false,
+        leapYearStrategy: LeapYearStrategy.DropFirstWeek
       }
     
       for (const yearData of lastDayBeforeEomExceptLeapYear) {

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -10,6 +10,7 @@ import {
   WeekCalculation,
   NRFCalendarOptions,
   LeapYearStrategy,
+  RetailCalendar,
 } from '../src/types'
 import { nrfYears } from './data/nrf_years'
 import { lastDayBeforeEOMYears } from './data/last_day_before_eom_years'
@@ -149,6 +150,43 @@ describe('RetailCalendar', () => {
           const firstMonth = calendar.months[0]
           expect(firstMonth.weeks[0]).not.toEqual(firstWeek)
           expect(firstMonth.weeks[0].weekOfYear).toEqual(0)
+        })
+      })
+
+      describe('when inserting a week in penultimate month', () => {
+        let calendar: RetailCalendar;
+
+        beforeEach(() => {
+          calendar = new RetailCalendarFactory(
+            { ...NRFCalendarOptions, weekGrouping: WeekGrouping.Group445, leapYearStrategy: LeapYearStrategy.AddToPenultimateMonth },
+            2017,
+          )
+        })
+        it('keeps the first week in the year', () => {
+          const firstWeek = calendar.weeks[0]
+          expect(firstWeek.monthOfYear).toBe(1)
+          expect(firstWeek.weekOfMonth).toBe(0)
+          expect(firstWeek.weekOfYear).toBe(0)
+          expect(firstWeek.weekOfQuarter).toBe(0)
+          const firstMonth = calendar.months[0]
+          expect(firstMonth.weeks[0]).toEqual(firstWeek)
+          expect(firstMonth.weeks[0].weekOfYear).toEqual(0)
+        })
+        it('keeps the last week in the year', () => {
+          const lastWeek = calendar.weeks[52]
+          expect(lastWeek.monthOfYear).toBe(12)
+          expect(lastWeek.weekOfMonth).toBe(4)
+          expect(lastWeek.weekOfYear).toBe(52)
+        })
+        it('adds a week to the 11th month', () => {
+          const expectedMonthLengthsInWeeks = [4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 5, 5]
+          const actualMonthLengthsInWeeks = calendar.months.map((month) => month.weeks.length)
+
+          expect(expectedMonthLengthsInWeeks).toEqual(actualMonthLengthsInWeeks)
+
+          const secondWeekInYear = calendar.weeks[1]
+          expect(secondWeekInYear.weekOfYear).toBe(1)
+
         })
       })
 

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -9,6 +9,7 @@ import {
   WeekGrouping,
   LastDayStrategy,
   LastMonthOfYear,
+  LeapYearStrategy,
 } from './types'
 
 import { CalendarMonth } from './calendar_month'
@@ -147,7 +148,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       return weekIndex
     }
 
-    if (this.options.restated) {
+    if (this.options.leapYearStrategy == LeapYearStrategy.Restated) {
       // If restated shift all weeks by -1
       return weekIndex - 1
     } else if (weekIndex === 52) {

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -185,7 +185,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
         break;
     }
 
-    if(this.options.leapYearStrategy === LeapYearStrategy.AddToPenultimateMonth && this.numberOfWeeks === 53)
+    if(this.leapYearStrategy === LeapYearStrategy.AddToPenultimateMonth && this.numberOfWeeks === 53)
       weekDistribution[10]++
 
     return weekDistribution;
@@ -196,7 +196,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       return weekIndex
     }
 
-    switch(this.options.leapYearStrategy) {
+    switch(this.leapYearStrategy) {
       case LeapYearStrategy.Restated:
         return weekIndex - 1
       case LeapYearStrategy.AddToPenultimateMonth:

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -35,6 +35,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     this.year = year
     this.options = calendarOptions
     this.calendarYear = this.getAdjustedGregorianYear(year)
+    this.leapYearStrategy = this.getLeapYearStrategy()
     this.numberOfWeeks = this.calculateNumberOfWeeks()
     this.lastDayOfYear = this.calculateLastDayOfYear(this.calendarYear)
     this.firstDayOfYear = moment(this.lastDayOfYear)
@@ -43,7 +44,6 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       .startOf('day')
     this.weeks = this.generateWeeks()
     this.months = this.generateMonths()
-    this.leapYearStrategy = this.getLeapYearStrategy()
   }
 
   getLeapYearStrategy() {

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -29,6 +29,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
   options: RetailCalendarOptions
   lastDayOfYear: moment.Moment
   firstDayOfYear: moment.Moment
+  leapYearStrategy: LeapYearStrategy;
 
   constructor(calendarOptions: RetailCalendarOptions, year: number) {
     this.year = year
@@ -42,6 +43,32 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       .startOf('day')
     this.weeks = this.generateWeeks()
     this.months = this.generateMonths()
+    this.leapYearStrategy = this.getLeapYearStrategy()
+  }
+
+  getLeapYearStrategy() {
+    if(this.options.restated === undefined && this.options.leapYearStrategy === undefined) {
+      throw(new Error("One of leapYearStrategy or restated options are required"))
+    }
+
+    if (this.options.restated !== undefined) {
+      // tslint:disable-next-line:no-console
+      console.warn('restated option is deprecated. Please use leapYearStrategy instead')
+    }
+
+    if(this.options.restated !== undefined && this.options.leapYearStrategy !== undefined) {
+      throw(new Error("Only one of leapYearStrategy or restated options can be given"))
+    }
+
+    if(this.options.restated !== undefined && this.options.restated === true) {
+      return LeapYearStrategy.Restated
+    }
+
+    if (this.options.leapYearStrategy !== undefined) {
+      return this.options.leapYearStrategy
+    }
+
+    return LeapYearStrategy.DropFirstWeek
   }
 
   generateMonths(): RetailCalendarMonth[] {

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -77,18 +77,18 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
   generateWeeks(): RetailCalendarWeek[] {
     const weeks = []
     for (let index = 0; index < this.numberOfWeeks; index++) {
-      const restatedWeekIndex = this.getRestatedWeekIndex(index)
+      const weekIndex = this.getWeekIndex(index)
       const [
         monthOfYear,
         weekOfMonth,
         weekOfQuarter,
         quarterOfYear,
-      ] = this.getMonthAndWeekOfMonthOfRestatedWeek(restatedWeekIndex)
+      ] = this.getMonthAndWeekOfMonthOfWeek(weekIndex)
       const start = moment(this.firstDayOfYear).add(index, 'week')
       const end = moment(start).add(1, 'week').subtract(1, 'day').endOf('day')
       weeks.push(
         new CalendarWeek(
-          restatedWeekIndex,
+          weekIndex,
           weekOfMonth,
           weekOfQuarter,
           monthOfYear,
@@ -101,7 +101,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     return weeks
   }
 
-  getMonthAndWeekOfMonthOfRestatedWeek(
+  getMonthAndWeekOfMonthOfWeek(
     weekIndex: number,
   ): [number, number, number, number] {
     
@@ -164,7 +164,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     return weekDistribution;
   }
 
-  getRestatedWeekIndex(weekIndex: number): number {
+  getWeekIndex(weekIndex: number): number {
     if (this.numberOfWeeks !== 53) {
       return weekIndex
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,16 +33,21 @@ export enum WeekCalculation {
   FirstBOWOfFirstMonth,
 }
 
+export enum LeapYearStrategy {
+  Restated,
+  DropFirstWeek
+}
+
 export interface RetailCalendarOptions {
   weekGrouping: WeekGrouping
   lastDayOfWeek: LastDayOfWeek
   lastMonthOfYear: LastMonthOfYear | number
   weekCalculation: WeekCalculation
   /**
-   * If true, 53rd week will belong to last month in leap year. First week won't belong to any month.
-   * If false, 53rd week won't belong to any month in leap year. First week will belong to the first month.
+   * If LeapYearStrategy.Restated, 53rd week will belong to last month in year. First week won't belong to any month.
+   * If LeapYearStrategy.DropFirstWeek, 53rd week won't belong to any month in year. First week will belong to the first month.
    */
-  restated: boolean
+  leapYearStrategy: LeapYearStrategy
   beginningMonthIndex?: number
 }
 
@@ -51,7 +56,7 @@ export const NRFCalendarOptions: RetailCalendarOptions = {
   lastDayOfWeek: LastDayOfWeek.Saturday,
   lastMonthOfYear: LastMonthOfYear.January,
   weekCalculation: WeekCalculation.LastDayNearestEOM,
-  restated: true,
+  leapYearStrategy: LeapYearStrategy.Restated 
 }
 
 export type RetailCalendarConstructor = new (

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,8 @@ export enum WeekCalculation {
 
 export enum LeapYearStrategy {
   Restated,
-  DropFirstWeek
+  DropFirstWeek,
+  AddToPenultimateMonth
 }
 
 export interface RetailCalendarOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface RetailCalendarOptions {
    * Note: restated: true is a deprecated option that is replaced by LeapYearStrategy.Restated
    */
   leapYearStrategy?: LeapYearStrategy
+   /** @deprecated use leapYearStrategy field instead */
   restated?: boolean
   beginningMonthIndex?: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,8 +47,10 @@ export interface RetailCalendarOptions {
   /**
    * If LeapYearStrategy.Restated, 53rd week will belong to last month in year. First week won't belong to any month.
    * If LeapYearStrategy.DropFirstWeek, 53rd week won't belong to any month in year. First week will belong to the first month.
+   * Note: restated: true is a deprecated option that is replaced by LeapYearStrategy.Restated
    */
-  leapYearStrategy: LeapYearStrategy
+  leapYearStrategy?: LeapYearStrategy
+  restated?: boolean
   beginningMonthIndex?: number
 }
 
@@ -66,6 +68,7 @@ export type RetailCalendarConstructor = new (
 ) => RetailCalendar
 
 export interface RetailCalendar {
+  leapYearStrategy: LeapYearStrategy
   year: number
   numberOfWeeks: number
   months: RetailCalendarMonth[]


### PR DESCRIPTION
With these changes the user of this library will be able to specify `Restated`, `DropFirstWeek`, or `AddToPenultimateMonth` as the leap year strategy.

An example `RetailCalendarOptions` will look like this for `Restated`

```javascript
RetailCalendarOptions = {
  weekGrouping: WeekGrouping.Group445,
  lastDayOfWeek: LastDayOfWeek.Saturday,
  lastMonthOfYear: LastMonthOfYear.January,
  weekCalculation: WeekCalculation.LastDayNearestEOM,
  leapYearStrategy: LeapYearStrategy.Restated # used to be: restated: true
}

```
The details of the new leap year strategy: `AddToPenultimateMonth` are in #21 

Fixes #21 