### PR TITLE
Do not pass year values to Date constructor

### DIFF
--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -462,4 +462,19 @@ describe('RetailCalendar', () => {
       }
     })
   })
+
+  describe("given 0 year", () => {
+    it("it does not generate more than 53 weeks", () => {
+      const options: RetailCalendarOptions = {
+        weekGrouping: WeekGrouping.Group454,
+        leapYearStrategy: LeapYearStrategy.Restated,
+        lastDayOfWeek: LastDayOfWeek.Saturday,
+        lastMonthOfYear: LastMonthOfYear.December,
+        weekCalculation: WeekCalculation.LastDayNearestEOM,
+        beginningMonthIndex: 0
+      };
+      const calendar = new RetailCalendarFactory(options, 0);
+      expect(calendar.weeks.length).toBeLessThanOrEqual(53);
+    })
+  })
 })

--- a/__tests__/utils/parser.ts
+++ b/__tests__/utils/parser.ts
@@ -2,10 +2,18 @@ import { endOfDay, startOfDay } from "../../src/date_utils"
 
 export function parseStartDate(startDate: string): Date {
     const [year, month, day] = startDate.split('-')
-    return startOfDay(new Date(parseInt(year), parseInt(month) - 1, parseInt(day)))
+    const date = new Date()
+    date.setFullYear(parseInt(year))
+    date.setMonth(parseInt(month) - 1)
+    date.setDate(parseInt(day))
+    return startOfDay(date)
 }
 
 export function parseEndDate(endDate: string): Date {
     const [year, month, day] = endDate.split('-')
-    return endOfDay(new Date(parseInt(year), parseInt(month) - 1, parseInt(day)))
+    const date = new Date()
+    date.setFullYear(parseInt(year))
+    date.setMonth(parseInt(month) - 1)
+    date.setDate(parseInt(day))
+    return endOfDay(date)
 }

--- a/src/date_utils.ts
+++ b/src/date_utils.ts
@@ -1,13 +1,13 @@
 export function addDaysToDate(date: Date, days: number): Date {
-  return new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate() + days,
-    date.getHours(),
-    date.getMinutes(),
-    date.getSeconds(),
-    date.getMilliseconds(),
-  )
+  const newDate = new Date();
+  newDate.setFullYear(date.getFullYear());
+  newDate.setMonth(date.getMonth());
+  newDate.setDate(date.getDate() + days);
+  newDate.setHours(date.getHours());
+  newDate.setMinutes(date.getMinutes());
+  newDate.setSeconds(date.getSeconds());
+  newDate.setMilliseconds(date.getMilliseconds());
+  return newDate;
 }
 
 export function addWeeksToDate(date: Date, weeks: number): Date {

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -265,9 +265,12 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
   }
 
   calculateLastDayOfYear(year: number): Date {
-    const lastDayOfYear = endOfMonth(
-      new Date(year, this.options.lastMonthOfYear, 1),
-    )
+    const firstDayOfLastMonthOfYear = new Date()
+    firstDayOfLastMonthOfYear.setFullYear(year)
+    firstDayOfLastMonthOfYear.setMonth(this.options.lastMonthOfYear)
+    firstDayOfLastMonthOfYear.setDate(1)
+
+    const lastDayOfYear = endOfMonth(firstDayOfLastMonthOfYear)
     const lastIsoWeekDay = this.options.lastDayOfWeek
     const weekCalculation = this.getWeekCalculationStrategy(
       this.options.weekCalculation,


### PR DESCRIPTION
This fixes issues around 0-99 years.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#interpretation_of_two-digit_years