### PR TITLE
Remove week -1 on non-restated leap years

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,14 @@ LAST week of year is "dropped".
 ```javascript
 // Restated calendar example.
 // First week of year has no month.
-calendar.weeks[52].weekOfYear // -1
+calendar.weeks[52].weekOfYear // 52
 calendar.weeks[52].weekOfMonth // -1
 calendar.weeks[52].monthOfYear // -1
 
 // First month starts from 1st week
 calendar.months[0].weeks[0].weekOfYear // 0
 ```
+⚠ *previous versions of this library returned weekOfYear as -1, this is no longer the case. Last week's weekOfYear is 52* ⚠
 ⚠ *previous versions of this library used the `restated: false` option to specify a "Drop Last Week" leap year strategy. This still works but is deprecated!* ⚠
 
 #### Add to Penultimate Month

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -280,7 +280,7 @@ describe('RetailCalendar', () => {
           const lastWeek = calendar.weeks[52]
           expect(lastWeek.monthOfYear).toBe(-1)
           expect(lastWeek.weekOfMonth).toBe(-1)
-          expect(lastWeek.weekOfYear).toBe(-1)
+          expect(lastWeek.weekOfYear).toBe(52)
 
           const firstMonth = calendar.months[0]
           expect(firstMonth.weeks[0].weekOfYear).toEqual(0)

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -272,15 +272,40 @@ describe('RetailCalendar', () => {
       })
 
       describe('when not restated', () => {
-        it('does not assign any months to last week', () => {
-          const calendar = new RetailCalendarFactory(
-            { ...NRFCalendarOptions, leapYearStrategy: LeapYearStrategy.DropLastWeek },
-            2017,
-          )
+        const notRestatedCalendarOptions = { ...NRFCalendarOptions, leapYearStrategy: LeapYearStrategy.DropLastWeek }
+
+        it("does not return a week -1", () => {
+          const calendar = new RetailCalendarFactory(notRestatedCalendarOptions, 2017)
+          const leapWeek = calendar.weeks.find((week) => week.weekOfYear === -1)
+
+          expect(leapWeek).toBeUndefined()
+        });
+
+        it("returns week 52 as the last week of the year", () => {
+          const calendar = new RetailCalendarFactory(notRestatedCalendarOptions, 2017)
           const lastWeek = calendar.weeks[52]
+          expect(calendar.weeks).toHaveLength(53)
           expect(lastWeek.monthOfYear).toBe(-1)
           expect(lastWeek.weekOfMonth).toBe(-1)
           expect(lastWeek.weekOfYear).toBe(52)
+        });
+
+        it("assigns first 52 weeks to months and quarters", () => {
+          const calendar = new RetailCalendarFactory(notRestatedCalendarOptions, 2017)
+          const first52Weeks = calendar.weeks.slice(0, 52)
+          // 4 weeks in Jan, 5 in Feb, 4 in Mar and repeats in each quarter
+          // Check that the first 52 weeks are assigned to months and quarters correctly
+          first52Weeks.forEach((week, index) => {
+            const expectedQuarterOfYear = Math.floor(index / 13) + 1;
+            const expectedWeekOfQuarter = (index % 13);
+            expect(week.quarterOfYear).toBe(expectedQuarterOfYear);
+            expect(week.weekOfQuarter).toBe(expectedWeekOfQuarter);
+          });
+        });
+
+        it('does not assign any months to last week', () => {
+          const calendar = new RetailCalendarFactory( notRestatedCalendarOptions, 2017)
+          const lastWeek = calendar.weeks[52]
 
           const firstMonth = calendar.months[0]
           expect(firstMonth.weeks[0].weekOfYear).toEqual(0)

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -260,7 +260,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       case LeapYearStrategy.AddToPenultimateMonth:
         return weekIndex
       default:
-        return weekIndex === 52 ? -1 : weekIndex
+        return weekIndex
     }
   }
 


### PR DESCRIPTION
weekOfYear value of 53rd week on non-restated leap years is now 52. It used to be -1.