### PR TITLE
Feature/Remove Restated Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ const calendar = new RetailCalendarFactory(
     weekGrouping: WeekGrouping.Group454,
     lastDayOfWeek: LastDayOfWeek.Saturday,
     lastMonthOfYear: LastMonthOfYear.January,
-    leapYearStrategy: LeapYearStrategy.DropLastWeek // deprecated: restated: false
   },
   2017,
 )
@@ -102,38 +101,17 @@ calendar.weeks[0].gregorianEndDate // Date
 ### 53 week years
 
 Based on given configuration, a year may contain 53 weeks.
-This complicates comparing months to previous year. This case is handled specially based on the given [LeapYearStrategy](#LeapYearStrategy) option.
 
 #### Restated
 
-If `leapYearStrategy` is `LeapYearStrategy.Restated` 
+⚠ *previous versions of this library used the LeapYearStrategy option to configure restated behavior. This is no longer supported. All 53 week calendars are not restated* ⚠
 
-FIRST week of year is "dropped". It doesn't belong the any month.
+#### Dropping Last Week
 
-```javascript
-// Restated calendar example.
-// First week of year has no month.
-// Note that first week's weekOfYear is -1.
-calendar.numberOfWeeks // 53
-calendar.weeks[0].weekOfYear // -1
-calendar.weeks[0].weekOfMonth // -1
-calendar.weeks[0].monthOfYear // -1
-
-// First month still starts from first week
-calendar.months[0].weeks[0].weekOfYear // 0
-```
-
-⚠ *previous versions of this library used the `restated: true` option to specify a Restated leap year strategy. This still works but is deprecated!* ⚠
-
-#### Drop Last Week
-
-If `leapYearStrategy` is `LeapYearStrategy.DropLastWeek`
-
-LAST week of year is "dropped".
+LAST week of year is "dropped" for 53-week years. This is the default behavior.
 
 ```javascript
-// Restated calendar example.
-// First week of year has no month.
+// Last week of year has no month.
 calendar.weeks[52].weekOfYear // 52
 calendar.weeks[52].weekOfMonth // -1
 calendar.weeks[52].monthOfYear // -1
@@ -142,11 +120,10 @@ calendar.weeks[52].monthOfYear // -1
 calendar.months[0].weeks[0].weekOfYear // 0
 ```
 ⚠ *previous versions of this library returned weekOfYear as -1, this is no longer the case. Last week's weekOfYear is 52* ⚠
-⚠ *previous versions of this library used the `restated: false` option to specify a "Drop Last Week" leap year strategy. This still works but is deprecated!* ⚠
 
 #### Add to Penultimate Month
 
-If `leapYearStrategy` is `LeapYearStrategy.AddToPenultimateMonth`
+If `addLeapWeekToPenultimateMonth` is `true`,
 
 extra week is "added" to the ELEVENTH month
 
@@ -155,6 +132,9 @@ extra week is "added" to the ELEVENTH month
 // 11th Month has 5 weeks instead of 4
 calendar.months[10].weeks.length //5
 ```
+
+⚠ *previous versions of this library supported `leapYearStrategy` option value `LeapYearStrategy.AddToPenultimateMonth` for the same behavior. `leapYearStrategy` is no longer supported* ⚠
+
 ### Options
 
 #### LastDayOfWeek
@@ -167,11 +147,11 @@ Identifies which method to use when calculating end of the retail calendar year.
 
 See [4-4-5 Calendar](https://en.wikipedia.org/wiki/4%E2%80%934%E2%80%935_calendar) article for how both of these methods work.
 
-- WeekCalculation.LastDayNearestEOM: Use the last end of retail week, nearest the end of last gregorian month in the year.
+- WeekCalculation.LastDayNearestEOM: Use the last end of retail week, nearest the end of last Gregorian month in the year.
 
-- WeekCalculation.LastDayBeforeEOM: Use the last end of retail week, before the end of last gregorian month in the year.
+- WeekCalculation.LastDayBeforeEOM: Use the last end of retail week, before the end of last Gregorian month in the year.
 
-- WeekCalculation.LastDayBeforeEomExceptLeapYear: Use the last end of retail week, before the end of last gregorian month in the year. If next year is leap year (has 53 weeks), make this year leap year by moving end of this year by 1 week forward.
+- WeekCalculation.LastDayBeforeEomExceptLeapYear: Use the last end of retail week, before the end of last Gregorian month in the year. If next year is leap year (has 53 weeks), make this year leap year by moving end of this year by 1 week forward.
 
 - WeekCalculation.FirstBOWOfFirstMonth: Use the first, beginning of week day, of the start month as the start day of year.
 
@@ -190,7 +170,9 @@ Specifies how many weeks each month has in a quarter.
 - `WeekGrouping.Group544`: 1st month has 5 weeks, 2nd has 4, 3rd has 4. Repeats for each quarter.
 - `WeekGrouping.Group445`: 1st month has 4 weeks, 2nd has 4, 3rd has 5. Repeats for each quarter.
 
-#### LeapYearStrategy
+If `addLeapWeekToPenultimateMonth` is set to `true`, then the penultimate month will not abide this rule, as it will have an extra week.
+
+#### LeapYearStrategy [Removed]
 
 `enum`
 
@@ -202,7 +184,7 @@ If the year is a leap year (in the context of a retail calendar that means it ha
 
 This option has no effect on 52 week years.
 
-#### restated [Deprecated]
+#### restated [Removed]
 ⚠ *This option has been superseded by [LeapYearStrategy](#LeapYearStrategy)* ⚠
 
 `boolean`. If true, in leap years, first week is not included in any month. Otherwise, in leap years, last week is not included in any month.

--- a/__tests__/data/nrf_2018.ts
+++ b/__tests__/data/nrf_2018.ts
@@ -61,10 +61,10 @@ export const nrf2018 = [
   },
 ]
 
-export const nrf2017Restated = [
+export const nrf2017NotRestated = [
   {
     monthOfYear: 0,
-    start: '2017-02-05',
-    end: '2017-03-04',
-  },
-]
+    start: '2017-01-29',
+    end: '2017-02-25',
+  }
+];

--- a/__tests__/days.test.ts
+++ b/__tests__/days.test.ts
@@ -92,10 +92,10 @@ describe("RetailCalendar", () => {
         it("should return correct first day information", () => {
             const firstDay = calendar.days[0]
             expect(firstDay.dayOfWeek).toBe(1)
-            expect(firstDay.dayOfMonth).toBe(-1)
+            expect(firstDay.dayOfMonth).toBe(1)
             expect(firstDay.dayOfYear).toBe(1)
-            expect(firstDay.monthOfYear).toBe(-1)
-            expect(firstDay.weekOfYear).toBe(-1)
+            expect(firstDay.monthOfYear).toBe(1)
+            expect(firstDay.weekOfYear).toBe(0)
             expect(firstDay.gregorianDayOfYear).toBe(29)
             expect(firstDay.gregorianMonthOfYear).toBe(1) // January
             expect(firstDay.gregorianStartDate).toEqual(new Date(2023, 0, 29)) // January 29th 2023
@@ -105,10 +105,10 @@ describe("RetailCalendar", () => {
         it("should return correct second day information", () => {
             const secondDay = calendar.days[1]
             expect(secondDay.dayOfWeek).toBe(2)
-            expect(secondDay.dayOfMonth).toBe(-1)
+            expect(secondDay.dayOfMonth).toBe(2)
             expect(secondDay.dayOfYear).toBe(2)
-            expect(secondDay.monthOfYear).toBe(-1)
-            expect(secondDay.weekOfYear).toBe(-1)
+            expect(secondDay.monthOfYear).toBe(1)
+            expect(secondDay.weekOfYear).toBe(0)
             expect(secondDay.gregorianDayOfYear).toBe(30)
             expect(secondDay.gregorianMonthOfYear).toBe(1) // January
             expect(secondDay.gregorianStartDate).toEqual(new Date(2023, 0, 30)) // January 30th 2023
@@ -118,10 +118,10 @@ describe("RetailCalendar", () => {
         it("should return correct third day information", () => {
             const thirdDay = calendar.days[2]
             expect(thirdDay.dayOfWeek).toBe(3)
-            expect(thirdDay.dayOfMonth).toBe(-1)
+            expect(thirdDay.dayOfMonth).toBe(3)
             expect(thirdDay.dayOfYear).toBe(3)
-            expect(thirdDay.monthOfYear).toBe(-1)
-            expect(thirdDay.weekOfYear).toBe(-1)
+            expect(thirdDay.monthOfYear).toBe(1)
+            expect(thirdDay.weekOfYear).toBe(0)
             expect(thirdDay.gregorianDayOfYear).toBe(31)
             expect(thirdDay.gregorianMonthOfYear).toBe(1) // January
             expect(thirdDay.gregorianStartDate).toEqual(new Date(2023, 0, 31)) // January 31th 2023
@@ -130,11 +130,11 @@ describe("RetailCalendar", () => {
 
         it("should return correct last day information", () => {
             const lastDay = calendar.days[53 * 7 - 1]
-            expect(lastDay.dayOfMonth).toBe(28)
+            expect(lastDay.dayOfMonth).toBe(-1)
             expect(lastDay.dayOfWeek).toBe(7)
             expect(lastDay.dayOfYear).toBe(371)
-            expect(lastDay.monthOfYear).toBe(12)
-            expect(lastDay.weekOfYear).toBe(51)
+            expect(lastDay.monthOfYear).toBe(-1)
+            expect(lastDay.weekOfYear).toBe(52)
             expect(lastDay.gregorianDayOfYear).toBe(34)
             expect(lastDay.gregorianMonthOfYear).toBe(2) // February
             expect(lastDay.gregorianStartDate).toEqual(new Date(2024, 1, 3)) // Feb 3rd 2024
@@ -143,12 +143,12 @@ describe("RetailCalendar", () => {
         });
 
         it("should return correct random day information", () => {
-            const randomDay = calendar.days[31 * 7 + 1] // 31st week, 2nd day (first week is leap week)
-            expect(randomDay.dayOfMonth).toBe(2)
+            const randomDay = calendar.days[31 * 7 + 1] // 32nd week, 2nd day
+            expect(randomDay.dayOfMonth).toBe(9)
             expect(randomDay.dayOfWeek).toBe(2)
             expect(randomDay.dayOfYear).toBe(31 * 7 + 2)
             expect(randomDay.monthOfYear).toBe(8)
-            expect(randomDay.weekOfYear).toBe(30)
+            expect(randomDay.weekOfYear).toBe(31)
             expect(randomDay.gregorianDayOfYear).toBe(247)
             expect(randomDay.gregorianMonthOfYear).toBe(9) // September
             expect(randomDay.gregorianStartDate).toEqual(new Date(2023, 8, 4)) // September 4th 2023

--- a/__tests__/matchers/be_the_same_week_as.ts
+++ b/__tests__/matchers/be_the_same_week_as.ts
@@ -1,4 +1,3 @@
-import { endOfDay } from "../../src/date_utils"
 import { parseEndDate, parseStartDate } from "../utils/parser";
 
 expect.extend({

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -9,7 +9,6 @@ import {
   LastMonthOfYear,
   WeekCalculation,
   NRFCalendarOptions,
-  LeapYearStrategy,
   RetailCalendar,
 } from '../src/types'
 import { nrfYears } from './data/nrf_years'
@@ -23,70 +22,7 @@ import { parseEndDate, parseStartDate } from './utils/parser';
 
 
 describe('RetailCalendar', () => {
-  describe("leap year strategy options", () => {
-
-    describe('when neither restated nor leapYearStrategy is provided', () => {
-      it('throws an error', () => {
-        expect(() => {
-          new RetailCalendarFactory({
-            weekGrouping: WeekGrouping.Group454,
-            lastDayOfWeek: LastDayOfWeek.Saturday,
-            lastMonthOfYear: LastMonthOfYear.January,
-            weekCalculation: WeekCalculation.LastDayNearestEOM,
-          }, 2018)
-        }).toThrowError(/leapYearStrategy or restated/)
-      })
-    })
-
-    describe("when restated is provided and its true", () => {
-      it("emits a warning", () => {
-        jest.spyOn(console, 'warn').mockImplementation()
-        const retailCalendar = new RetailCalendarFactory({
-          weekGrouping: WeekGrouping.Group454,
-          lastDayOfWeek: LastDayOfWeek.Saturday,
-          lastMonthOfYear: LastMonthOfYear.January,
-          weekCalculation: WeekCalculation.LastDayNearestEOM,
-          restated: true
-        }, 2017)
-
-        expect(retailCalendar.leapYearStrategy).toBe(LeapYearStrategy.Restated)
-        expect(console.warn).toHaveBeenCalledWith("restated option is deprecated. Please use leapYearStrategy instead")
-      })
-    })
-
-    describe("when restated is provided and its false", () => {
-      it("emits a warning", () => {
-        jest.spyOn(console, 'warn').mockImplementation()
-        const retailCalendar = new RetailCalendarFactory({
-          weekGrouping: WeekGrouping.Group454,
-          lastDayOfWeek: LastDayOfWeek.Saturday,
-          lastMonthOfYear: LastMonthOfYear.January,
-          weekCalculation: WeekCalculation.LastDayNearestEOM,
-          restated: false
-        }, 2017)
-
-        expect(retailCalendar.leapYearStrategy).toBe(LeapYearStrategy.DropLastWeek)
-        expect(console.warn).toHaveBeenCalledWith("restated option is deprecated. Please use leapYearStrategy instead")
-      })
-    })
-
-    describe("when restated and leapYearStrategy are provided", () => {
-      it('throws an erorr', () => {
-        expect(() => {
-          jest.spyOn(console, 'warn').mockImplementation()
-          const retailCalendar = new RetailCalendarFactory({
-            weekGrouping: WeekGrouping.Group454,
-            lastDayOfWeek: LastDayOfWeek.Saturday,
-            lastMonthOfYear: LastMonthOfYear.January,
-            weekCalculation: WeekCalculation.LastDayNearestEOM,
-            leapYearStrategy: LeapYearStrategy.Restated,
-            restated: false
-          }, 2017)
-        }).toThrowError(/Only one of leapYearStrategy or restated options can be given/)
-      })
-
-    })
-  })
+  // TODO: addLeapYearToPenultimate tests
 
   describe('Given Last Day Nearest EOM, 445, Penultimate Leap Year', () => {
     it('returns the right data for each week of 2022', () => {
@@ -95,7 +31,7 @@ describe('RetailCalendar', () => {
         weekGrouping: WeekGrouping.Group445,
         lastDayOfWeek: LastDayOfWeek.Friday,
         lastMonthOfYear: LastMonthOfYear.January,
-        leapYearStrategy: LeapYearStrategy.AddToPenultimateMonth
+        addLeapYearToPenultimateMonth: true,
       }, 2022)
 
       for (let weekIndex = 0; weekIndex < lastDayNearestEOM445PenultimateWeeks.length; weekIndex++) {
@@ -325,7 +261,6 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.August,
         weekCalculation: WeekCalculation.LastDayBeforeEOM,
-        leapYearStrategy: LeapYearStrategy.DropLastWeek
       }
 
       for (const { year, numberOfWeeks } of lastDayBeforeEOMYears) {
@@ -341,7 +276,6 @@ describe('RetailCalendar', () => {
           lastDayOfWeek: LastDayOfWeek.Saturday,
           lastMonthOfYear: LastMonthOfYear.August,
           weekCalculation: WeekCalculation.LastDayBeforeEOM,
-          leapYearStrategy: LeapYearStrategy.DropLastWeek
         }
         const calendar = new RetailCalendarFactory(calendarOptions, 2015)
         const expectedMonthLenthsInWeeks = [5, 4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 4]
@@ -359,7 +293,6 @@ describe('RetailCalendar', () => {
           lastDayOfWeek: LastDayOfWeek.Saturday,
           lastMonthOfYear: LastMonthOfYear.August,
           weekCalculation: WeekCalculation.LastDayBeforeEOM,
-          leapYearStrategy: LeapYearStrategy.DropLastWeek
         }
         const calendar = new RetailCalendarFactory(calendarOptions, 2015)
         const expectedMonthLenthsInWeeks = [4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 4, 5]
@@ -377,7 +310,6 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.December,
         weekCalculation: WeekCalculation.LastDayNearestEOM,
-        leapYearStrategy: LeapYearStrategy.Restated
       }
       const calendar = new RetailCalendarFactory(options, 2019)
       expect(calendar.months[11].gregorianStartDate.getFullYear()).toBe(2019)
@@ -391,7 +323,6 @@ describe('RetailCalendar', () => {
         lastDayOfWeek: LastDayOfWeek.Saturday,
         lastMonthOfYear: LastMonthOfYear.December,
         weekCalculation: WeekCalculation.FirstBOWOfFirstMonth,
-        leapYearStrategy: LeapYearStrategy.Restated
       }
 
       for (const yearData of firstBow) {

--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -1,6 +1,3 @@
-import { LastDayBeforeEOMExceptLeapYearStrategy } from '../src/last_day_before_eom_except_leap_year';
-import { LastDayBeforeEOMStrategy } from './../src/last_day_before_eom';
-import { FirstBOWOfFirstMonth } from '../src/first_bow_of_first_month'
 import { RetailCalendarFactory } from '../src/retail_calendar'
 import {
   RetailCalendarOptions,
@@ -17,7 +14,7 @@ import { nrf2018, nrf2017NotRestated } from './data/nrf_2018'
 import { firstBow } from './data/first_bow'
 import { lastDayBeforeEomExceptLeapYear } from './data/last_day_before_eom_except_leap_year';
 import { lastDayNearestEOM445PenultimateWeeks } from './data/last_day_nearest_eom_445_penultimate_weeks';
-import { endOfDay, startOfDay, toFormattedString } from '../src/date_utils';
+import { toFormattedString } from '../src/date_utils';
 import { parseEndDate, parseStartDate } from './utils/parser';
 
 

--- a/src/last_day_nearest_eom.ts
+++ b/src/last_day_nearest_eom.ts
@@ -1,5 +1,4 @@
 import {
-  addDaysToDate,
   addWeeksToDate,
   getDayDifference,
   setIsoWeekDay,

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,25 +33,15 @@ export enum WeekCalculation {
   FirstBOWOfFirstMonth,
 }
 
-export enum LeapYearStrategy {
-  Restated,
-  DropLastWeek,
-  AddToPenultimateMonth,
-}
-
 export interface RetailCalendarOptions {
   weekGrouping: WeekGrouping
   lastDayOfWeek: LastDayOfWeek
   lastMonthOfYear: LastMonthOfYear | number
   weekCalculation: WeekCalculation
   /**
-   * If LeapYearStrategy.Restated, 53rd week will belong to last month in year. First week won't belong to any month.
-   * If LeapYearStrategy.DropLastWeek, 53rd week won't belong to any month in year. First week will belong to the first month.
-   * Note: restated: true is a deprecated option that is replaced by LeapYearStrategy.Restated
+   * If the value of addLeapYearToPenultimateMonth is true, then the 11th month of the years that have 53 weeks will be extended by an additional week
    */
-  leapYearStrategy?: LeapYearStrategy
-  /** @deprecated use leapYearStrategy field instead */
-  restated?: boolean
+  addLeapYearToPenultimateMonth?: boolean
   beginningMonthIndex?: number
 }
 
@@ -60,7 +50,6 @@ export const NRFCalendarOptions: RetailCalendarOptions = {
   lastDayOfWeek: LastDayOfWeek.Saturday,
   lastMonthOfYear: LastMonthOfYear.January,
   weekCalculation: WeekCalculation.LastDayNearestEOM,
-  leapYearStrategy: LeapYearStrategy.Restated,
 }
 
 export type RetailCalendarConstructor = new (
@@ -69,12 +58,12 @@ export type RetailCalendarConstructor = new (
 ) => RetailCalendar
 
 export interface RetailCalendar {
-  leapYearStrategy: LeapYearStrategy
   year: number
   numberOfWeeks: number
   months: RetailCalendarMonth[]
   weeks: RetailCalendarWeek[]
   days: RetailCalendarDay[]
+  addLeapYearToPenultimateMonth: boolean
 }
 
 export interface RetailCalendarDay {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,9 @@ export interface RetailCalendarOptions {
   lastMonthOfYear: LastMonthOfYear | number
   weekCalculation: WeekCalculation
   /**
-   * If the value of addLeapYearToPenultimateMonth is true, then the 11th month of the years that have 53 weeks will be extended by an additional week
+   * If the value of addLeapWeekToPenultimateMonth is true, then the 11th month of the years that have 53 weeks will be extended by an additional week
    */
-  addLeapYearToPenultimateMonth?: boolean
+  addLeapWeekToPenultimateMonth?: boolean
   beginningMonthIndex?: number
 }
 
@@ -63,7 +63,7 @@ export interface RetailCalendar {
   months: RetailCalendarMonth[]
   weeks: RetailCalendarWeek[]
   days: RetailCalendarDay[]
-  addLeapYearToPenultimateMonth: boolean
+  addLeapWeekToPenultimateMonth: boolean
 }
 
 export interface RetailCalendarDay {


### PR DESCRIPTION
## Changes:
- Removed the `LeapYearStrategy` option from `RetailCalendarOptions`. Calendar behavior now defaults to dropping last week, i.e. `LeapYearStrategy.DropLastWeek` as in the previous version.
- Added `addLeapWeekToPenultimateMonth` boolean flag to `RetailCalendarOptions`.