### PR TITLE
Add penultimate day of week nearest EOM week calculation strategy

### DIFF
--- a/__tests__/retail_calendar.test.ts
+++ b/__tests__/retail_calendar.test.ts
@@ -433,6 +433,40 @@ describe('RetailCalendar', () => {
     })
   })
 
+  describe("PenultimateDayOfWeekNearestEOM calculation method", () => {
+    it("uses last day week for week calculation, but uses penultimate day for calculating year boundaries", () => {
+      // NRF Calendar has 53 weeks in 2023, last day of week is Saturday
+      const nrfCalendar = new RetailCalendarFactory(NRFCalendarOptions, 2023);
+      expect(nrfCalendar.weeks.length).toEqual(53)
+
+      // When last day of week is changed to Sunday, NRF Calendar has 52 weeks in 2023
+      const nrfOptionsWithSundayAsLastDayOfWeek = {
+        ...NRFCalendarOptions,
+        lastDayOfWeek: LastDayOfWeek.Sunday,
+      }
+      const nrfCalendarWithSundayAsLastDayOfWeek = new RetailCalendarFactory(nrfOptionsWithSundayAsLastDayOfWeek, 2023);
+      expect(nrfCalendarWithSundayAsLastDayOfWeek.weeks.length).toEqual(52)
+
+
+      // When using PenultimateDayNearestEndOfMonth, NRF Calendar with Sunday as last day of week has 53 weeks in 2023
+      // like original NRF Calendar
+      const options = {
+        ...NRFCalendarOptions,
+        lastDayOfWeek: LastDayOfWeek.Sunday,
+        weekCalculation: WeekCalculation.PenultimateDayOfWeekNearestEOM,
+      }
+      const calendar = new RetailCalendarFactory(options, 2023)
+      expect(calendar.weeks.length).toEqual(53)
+      // Check that each week Gregorian end date is a Sunday
+      calendar.weeks.forEach((week) => {
+          expect(week.gregorianEndDate.getDay()).toEqual(0)
+      })
+      // Check that calendar year starts at Jan 30 2023 Sunday and end at Feb 4 2024 Sunday
+      expect(toFormattedString(calendar.weeks[0].gregorianStartDate)).toEqual("2023-01-30")
+      expect(toFormattedString(calendar.weeks[52].gregorianEndDate)).toEqual("2024-02-04")
+    });
+  });
+
   describe("Memoization", () => {
     it("should return same retail calendar using same calendar options and year", () => {
       const options: RetailCalendarOptions = {

--- a/src/penultimate_day_of_week_nearest_eom.ts
+++ b/src/penultimate_day_of_week_nearest_eom.ts
@@ -1,0 +1,22 @@
+import {addDaysToDate, addWeeksToDate, getDayDifference, setIsoWeekDay} from './date_utils'
+import { LastDayStrategy } from './types'
+import {LastDayNearestEOMStrategy} from "./last_day_nearest_eom";
+
+export class PenultimateDayOfWeekNearestEOMStrategy implements LastDayStrategy {
+    getLastDayForGregorianLastDay(
+        lastDayOfGregorianYear: Date,
+        lastDayOfIsoWeek: number,
+    ): Date {
+        // get penultimate day of ISO week by moving one day back
+        const penultimateDayOfIsoWeek = lastDayOfIsoWeek === 0 ? 6 : lastDayOfIsoWeek - 1
+        // use last day nearest end of month logic
+        const lastDayNearestEOMStrategy = new LastDayNearestEOMStrategy()
+        const lastWeekOfYear =  lastDayNearestEOMStrategy.getLastDayForGregorianLastDay(
+            lastDayOfGregorianYear,
+            penultimateDayOfIsoWeek,
+        )
+
+        // move the day one day forward to get the last day of the week
+        return addDaysToDate(lastWeekOfYear, 1)
+    }
+}

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -31,6 +31,7 @@ import {
   createMemoizationKeyFromCalendarOptionsAndYear,
   memoize,
 } from './utils/memoization'
+import {PenultimateDayOfWeekNearestEOMStrategy} from "./penultimate_day_of_week_nearest_eom";
 
 const buildRetailCalendarFactory = memoize(
   (retailCalendarOptions: RetailCalendarOptions, year: number) =>
@@ -280,6 +281,8 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
         return new LastDayNearestEOMStrategy()
       case WeekCalculation.FirstBOWOfFirstMonth:
         return new FirstBOWOfFirstMonth()
+      case WeekCalculation.PenultimateDayOfWeekNearestEOM:
+        return new PenultimateDayOfWeekNearestEOMStrategy()
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export enum WeekCalculation {
   LastDayBeforeEomExceptLeapYear,
   LastDayNearestEOM,
   FirstBOWOfFirstMonth,
+  PenultimateDayOfWeekNearestEOM,
 }
 
 export interface RetailCalendarOptions {


### PR DESCRIPTION
Add a new week calculation strategy that uses last day of the week - 1 to calculate year boundaries.
The goal is to have the same years as leap years as NRF but have a different last day of week.