### PR TITLE
Support custom leap year

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,10 @@ Specifies how many weeks each month has in a quarter.
 #### addLeapWeekToMonth
 If `addLeapWeekToMonth` is set to `10`, then the penultimate month will not abide this rule, as it will have an extra week. This value is zero-indexed.
 
-#### customLeapYearOptions
-Overrides how leap years are calculated. If this is set, given `customLeapYearOptions.yearEndDate` will be the end of calendar year of `customLeapYearOptions.calendarYear`.
-Then remaining leap years will be calculated by `customLeapYearOptions.leapYearFrequency` option.
+#### leapYear, leapYearEndDate, leapYearFrequency
+Overrides how leap years are calculated. Used only if weekCalculation is set to `WeekCalculation.CustomLeapYear`.
+If these options are set, given `leapYearEndDate` will be the end of calendar year of `leapYear`.
+Then remaining leap years will be calculated using `leapYearFrequency` option.
 
 For given `{ yearEndDate: '2006-03-11', calendarYear: 2006, leapYearFrequency: 6 }` customLeapYearOptions, 2006 will be a leap year and the last day of the year will be 2006-03-11.
 Following leap years will be 2012, 2018, 2024 and so on.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ Specifies how many weeks each month has in a quarter.
 #### addLeapWeekToMonth
 If `addLeapWeekToMonth` is set to `10`, then the penultimate month will not abide this rule, as it will have an extra week. This value is zero-indexed.
 
+#### customLeapYearOptions
+Overrides how leap years are calculated. If this is set, given `customLeapYearOptions.yearEndDate` will be the end of calendar year of `customLeapYearOptions.calendarYear`.
+Then remaining leap years will be calculated by `customLeapYearOptions.leapYearFrequency` option.
+
+For given `{ yearEndDate: '2006-03-11', calendarYear: 2006, leapYearFrequency: 6 }` customLeapYearOptions, 2006 will be a leap year and the last day of the year will be 2006-03-11.
+Following leap years will be 2012, 2018, 2024 and so on.
+
 #### LeapYearStrategy [Removed]
 
 `enum`

--- a/__tests__/custom_leap_year.test.ts
+++ b/__tests__/custom_leap_year.test.ts
@@ -1,0 +1,81 @@
+import {
+    LastDayOfWeek,
+    LastMonthOfYear,
+    RetailCalendar, RetailCalendarFactory,
+    RetailCalendarOptions,
+    WeekCalculation,
+    WeekGrouping
+} from "../src";
+import {addDaysToDate, endOfDay, startOfDay} from "../src/date_utils";
+
+describe("Given CustomLeapYear calendar options", () => {
+    let customLeapYearCalendarOptions: RetailCalendarOptions;
+    beforeEach(() => {
+        customLeapYearCalendarOptions = {
+            customLeapYearOptions: {
+                calendarYear: 2006,
+                yearEndDate: "2006-03-11", // 2006 March 11th, Saturday
+                leapYearFrequency: 6,
+            },
+            weekCalculation: WeekCalculation.CustomLeapYear,
+            lastDayOfWeek:LastDayOfWeek.Saturday,
+            lastMonthOfYear: LastMonthOfYear.March,
+            weekGrouping: WeekGrouping.Group454,
+        };
+    });
+    // 2005 2011 2017 2023
+
+    it("should return 53 for first given leap year", () => {
+       const retailCalendar = RetailCalendarFactory.getRetailCalendar(customLeapYearCalendarOptions, 2006);
+         expect(retailCalendar.weeks.length).toEqual(53);
+         expect(retailCalendar.weeks[0].gregorianStartDate).toEqual(startOfDay(new Date("2005-03-06")));
+         expect(retailCalendar.weeks[52].gregorianEndDate).toEqual(endOfDay(new Date("2006-03-11")));
+    });
+
+    it("should return 53 weeks for year 2024", () => {
+        const retailCalendar = RetailCalendarFactory.getRetailCalendar(customLeapYearCalendarOptions, 2024);
+        expect(retailCalendar.weeks.length).toEqual(53);
+    });
+
+    it('should return 53 weeks for a past leap year', () => {
+        const retailCalendar = RetailCalendarFactory.getRetailCalendar(customLeapYearCalendarOptions, 2000);
+        expect(retailCalendar.weeks.length).toEqual(53);
+    });
+
+    it("should return correct end date for years between 2005 to 2030", () => {
+
+        // From 2005 to 2030
+        const expectedEndDateStrings = [
+            '2006-03-11',
+            '2007-03-10',
+            '2008-03-08',
+            '2009-03-07',
+            '2010-03-06',
+            '2011-03-05',
+            '2012-03-10',
+            '2013-03-09',
+            '2014-03-08',
+            '2015-03-07',
+            '2016-03-05',
+            '2017-03-04',
+            '2018-03-10',
+            '2019-03-09',
+            '2020-03-07',
+            '2021-03-06',
+            '2022-03-05',
+            '2023-03-04',
+            '2024-03-09',
+            '2025-03-08',
+            '2026-03-07',
+            '2027-03-06',
+            '2028-03-04',
+            '2029-03-03',
+            '2030-03-09',
+        ];
+        const expectedEndDates: Date[] = expectedEndDateStrings.map(dateString => endOfDay(new Date(dateString)));
+        for (let i = 2006; i < 2031; i++) {
+            const retailCalendar = RetailCalendarFactory.getRetailCalendar(customLeapYearCalendarOptions, i);
+            expect(retailCalendar.weeks[retailCalendar.weeks.length - 1].gregorianEndDate).toEqual(expectedEndDates[i - 2006]);
+        }
+    });
+});

--- a/__tests__/custom_leap_year.test.ts
+++ b/__tests__/custom_leap_year.test.ts
@@ -1,26 +1,24 @@
 import {
     LastDayOfWeek,
     LastMonthOfYear,
-    RetailCalendar, RetailCalendarFactory,
+    RetailCalendarFactory,
     RetailCalendarOptions,
     WeekCalculation,
     WeekGrouping
 } from "../src";
-import {addDaysToDate, endOfDay, startOfDay} from "../src/date_utils";
+import { endOfDay, startOfDay} from "../src/date_utils";
 
 describe("Given CustomLeapYear calendar options", () => {
     let customLeapYearCalendarOptions: RetailCalendarOptions;
     beforeEach(() => {
         customLeapYearCalendarOptions = {
-            customLeapYearOptions: {
-                calendarYear: 2006,
-                yearEndDate: "2006-03-11", // 2006 March 11th, Saturday
-                leapYearFrequency: 6,
-            },
             weekCalculation: WeekCalculation.CustomLeapYear,
             lastDayOfWeek:LastDayOfWeek.Saturday,
             lastMonthOfYear: LastMonthOfYear.March,
             weekGrouping: WeekGrouping.Group454,
+            leapYear: 2006,
+            leapYearEndDate: "2006-03-11", // 2006 March 11th, Saturday
+            leapYearFrequency: 6,
         };
     });
     // 2005 2011 2017 2023

--- a/__tests__/memoization.test.ts
+++ b/__tests__/memoization.test.ts
@@ -7,46 +7,19 @@ describe("createMemoizationKeyFromCalendarOptionsAndYear", () => {
         const customLeapYearOptions1 = {
             ...NRFCalendarOptions,
             weekCalculation: WeekCalculation.CustomLeapYear,
-            customLeapYearOptions: {
-                calendarYear: 2006,
-                yearEndDate: "2006-03-11",
-                leapYearFrequency: 6,
-            }
+            leapYear: 2006,
+            leapYearEndDate: "2006-03-11",
+            leapYearFrequency: 6,
         }
         const customLeapYearOptions2 = {
             ...NRFCalendarOptions,
             weekCalculation: WeekCalculation.CustomLeapYear,
-            customLeapYearOptions: {
-                calendarYear: 2006,
-                yearEndDate: "2006-03-11",
-                leapYearFrequency: 7,
-            }
+            leapYear: 2006,
+            leapYearEndDate: "2006-03-11",
+            leapYearFrequency: 7,
         }
         expect(createMemoizationKeyFromCalendarOptionsAndYear(customLeapYearOptions1, 2020))
             .not.toEqual(createMemoizationKeyFromCalendarOptionsAndYear(customLeapYearOptions2, 2020));
    });
 
-   it("takes less than 30ms to create 10000 different keys", () => {
-        const calendarConfigurations = Array.from({length: 10000}, () => generateNRFCalendarOptionWithRandomCustomLeapYearOptions());
-       const start = Date.now();
-         calendarConfigurations.forEach(calendarConfiguration => {
-              createMemoizationKeyFromCalendarOptionsAndYear(calendarConfiguration, 2020);
-         });
-         const end = Date.now();
-         expect(end - start).toBeLessThan(30);
-   })
 });
-
-
-function generateNRFCalendarOptionWithRandomCustomLeapYearOptions(): RetailCalendarOptions {
-    return {
-        ...NRFCalendarOptions,
-        weekCalculation: WeekCalculation.CustomLeapYear,
-        customLeapYearOptions: {
-            // Calendar year between 1988 and 50000
-            calendarYear: Math.floor(Math.random() * (50000 - 1988 + 1)) + 1988,
-            yearEndDate: "2006-03-11",
-            leapYearFrequency: 6,
-        }
-    }
-}

--- a/__tests__/memoization.test.ts
+++ b/__tests__/memoization.test.ts
@@ -1,0 +1,52 @@
+import {NRFCalendarOptions, RetailCalendarOptions, WeekCalculation} from "../src";
+import {createMemoizationKeyFromCalendarOptionsAndYear} from "../src/utils/memoization";
+
+describe("createMemoizationKeyFromCalendarOptionsAndYear", () => {
+   it("creates different keys for different custom leap year options", () => {
+        const commonOptions = NRFCalendarOptions;
+        const customLeapYearOptions1 = {
+            ...NRFCalendarOptions,
+            weekCalculation: WeekCalculation.CustomLeapYear,
+            customLeapYearOptions: {
+                calendarYear: 2006,
+                yearEndDate: "2006-03-11",
+                leapYearFrequency: 6,
+            }
+        }
+        const customLeapYearOptions2 = {
+            ...NRFCalendarOptions,
+            weekCalculation: WeekCalculation.CustomLeapYear,
+            customLeapYearOptions: {
+                calendarYear: 2006,
+                yearEndDate: "2006-03-11",
+                leapYearFrequency: 7,
+            }
+        }
+        expect(createMemoizationKeyFromCalendarOptionsAndYear(customLeapYearOptions1, 2020))
+            .not.toEqual(createMemoizationKeyFromCalendarOptionsAndYear(customLeapYearOptions2, 2020));
+   });
+
+   it("takes less than 30ms to create 10000 different keys", () => {
+        const calendarConfigurations = Array.from({length: 10000}, () => generateNRFCalendarOptionWithRandomCustomLeapYearOptions());
+       const start = Date.now();
+         calendarConfigurations.forEach(calendarConfiguration => {
+              createMemoizationKeyFromCalendarOptionsAndYear(calendarConfiguration, 2020);
+         });
+         const end = Date.now();
+         expect(end - start).toBeLessThan(30);
+   })
+});
+
+
+function generateNRFCalendarOptionWithRandomCustomLeapYearOptions(): RetailCalendarOptions {
+    return {
+        ...NRFCalendarOptions,
+        weekCalculation: WeekCalculation.CustomLeapYear,
+        customLeapYearOptions: {
+            // Calendar year between 1988 and 50000
+            calendarYear: Math.floor(Math.random() * (50000 - 1988 + 1)) + 1988,
+            yearEndDate: "2006-03-11",
+            leapYearFrequency: 6,
+        }
+    }
+}

--- a/src/custom_leap_year.ts
+++ b/src/custom_leap_year.ts
@@ -1,43 +1,48 @@
-import {LastDayStrategy} from "./types";
-import {addWeeksToDate} from "./date_utils";
+import { LastDayStrategy } from './types'
+import { addWeeksToDate } from './date_utils'
 
 export class CustomLeapYearStrategy implements LastDayStrategy {
-    leapYear: number
-    leapYearEndDate: string
-    leapYearFrequency: number
+  leapYear: number
+  leapYearEndDate: string
+  leapYearFrequency: number
 
-    constructor(leapYear: number, leapYearEndDate: string, leapYearFrequency: number) {
-        this.leapYear = leapYear;
-        this.leapYearEndDate = leapYearEndDate;
-        this.leapYearFrequency = leapYearFrequency;
+  constructor(
+    leapYear: number,
+    leapYearEndDate: string,
+    leapYearFrequency: number,
+  ) {
+    this.leapYear = leapYear
+    this.leapYearEndDate = leapYearEndDate
+    this.leapYearFrequency = leapYearFrequency
+  }
+  getLastDayForGregorianLastDay(
+    lastDayOfGregorianYear: Date,
+    isoLastDayOfWeek: number,
+    retailCalendarYear: number,
+  ): Date {
+    const startCalendarYear = this.leapYear
+    const startYearEndDate = this.leapYearEndDate
+    const yearDifference = retailCalendarYear - startCalendarYear
+    let yearEndDate = new Date(startYearEndDate)
+    if (yearDifference > 0) {
+      // start at the startCalendarYear + 1, because we already have the end date for the startCalendarYear
+      for (let i = startCalendarYear + 1; i <= retailCalendarYear; i += 1) {
+        const isLeapYear =
+          Math.abs(i - startCalendarYear) % this.leapYearFrequency === 0
+        const numberOfWeeks = isLeapYear ? 53 : 52
+        yearEndDate = addWeeksToDate(yearEndDate, numberOfWeeks)
+      }
+      return yearEndDate
+    } else if (yearDifference < 0) {
+      for (let i = startCalendarYear; i > retailCalendarYear; i -= 1) {
+        const isLeapYear =
+          Math.abs(i - startCalendarYear) % this.leapYearFrequency === 0
+        const numberOfWeeks = isLeapYear ? 53 : 52
+        yearEndDate = addWeeksToDate(yearEndDate, -numberOfWeeks)
+      }
+      return yearEndDate
     }
-    getLastDayForGregorianLastDay(
-        lastDayOfGregorianYear: Date,
-        isoLastDayOfWeek: number,
-        retailCalendarYear: number,
-    ): Date {
-        const startCalendarYear = this.leapYear;
-        const startYearEndDate = this.leapYearEndDate;
-        const yearDifference = retailCalendarYear - startCalendarYear;
-        let yearEndDate = new Date(startYearEndDate);
-        if (yearDifference > 0) {
-            // start at the startCalendarYear + 1, because we already have the end date for the startCalendarYear
-            for (let i = startCalendarYear + 1; i <= retailCalendarYear; i += 1) {
-                const isLeapYear = Math.abs(i - startCalendarYear) % this.leapYearFrequency === 0;
-                const numberOfWeeks = isLeapYear ? 53 : 52;
-                yearEndDate = addWeeksToDate(yearEndDate, numberOfWeeks);
-            }
-            return yearEndDate;
-        } else if (yearDifference < 0) {
-            for (let i = startCalendarYear; i > retailCalendarYear; i -= 1) {
-                const isLeapYear = Math.abs(i - startCalendarYear) % this.leapYearFrequency === 0;
-                const numberOfWeeks = isLeapYear ? 53 : 52;
-                yearEndDate = addWeeksToDate(yearEndDate, -numberOfWeeks);
-            }
-            return yearEndDate;
-        }
 
-        return yearEndDate;
-    }
-
+    return yearEndDate
+  }
 }

--- a/src/custom_leap_year.ts
+++ b/src/custom_leap_year.ts
@@ -1,31 +1,36 @@
-import {CustomLeapYearOptions, LastDayStrategy} from "./types";
+import {LastDayStrategy} from "./types";
 import {addWeeksToDate} from "./date_utils";
 
 export class CustomLeapYearStrategy implements LastDayStrategy {
-    customLastYearOptions: CustomLeapYearOptions;
+    leapYear: number
+    leapYearEndDate: string
+    leapYearFrequency: number
 
-    constructor(customLastYearOptions: CustomLeapYearOptions) {
-        this.customLastYearOptions = customLastYearOptions;
+    constructor(leapYear: number, leapYearEndDate: string, leapYearFrequency: number) {
+        this.leapYear = leapYear;
+        this.leapYearEndDate = leapYearEndDate;
+        this.leapYearFrequency = leapYearFrequency;
     }
     getLastDayForGregorianLastDay(
         lastDayOfGregorianYear: Date,
         isoLastDayOfWeek: number,
         retailCalendarYear: number,
     ): Date {
-        const { calendarYear: startCalendarYear, yearEndDate: startYearEndDate, leapYearFrequency } = this.customLastYearOptions;
+        const startCalendarYear = this.leapYear;
+        const startYearEndDate = this.leapYearEndDate;
         const yearDifference = retailCalendarYear - startCalendarYear;
         let yearEndDate = new Date(startYearEndDate);
         if (yearDifference > 0) {
             // start at the startCalendarYear + 1, because we already have the end date for the startCalendarYear
             for (let i = startCalendarYear + 1; i <= retailCalendarYear; i += 1) {
-                const isLeapYear = Math.abs(i - startCalendarYear) % leapYearFrequency === 0;
+                const isLeapYear = Math.abs(i - startCalendarYear) % this.leapYearFrequency === 0;
                 const numberOfWeeks = isLeapYear ? 53 : 52;
                 yearEndDate = addWeeksToDate(yearEndDate, numberOfWeeks);
             }
             return yearEndDate;
         } else if (yearDifference < 0) {
             for (let i = startCalendarYear; i > retailCalendarYear; i -= 1) {
-                const isLeapYear = Math.abs(i - startCalendarYear) % leapYearFrequency === 0;
+                const isLeapYear = Math.abs(i - startCalendarYear) % this.leapYearFrequency === 0;
                 const numberOfWeeks = isLeapYear ? 53 : 52;
                 yearEndDate = addWeeksToDate(yearEndDate, -numberOfWeeks);
             }

--- a/src/custom_leap_year.ts
+++ b/src/custom_leap_year.ts
@@ -1,0 +1,38 @@
+import {CustomLeapYearOptions, LastDayStrategy} from "./types";
+import {addWeeksToDate} from "./date_utils";
+
+export class CustomLeapYearStrategy implements LastDayStrategy {
+    customLastYearOptions: CustomLeapYearOptions;
+
+    constructor(customLastYearOptions: CustomLeapYearOptions) {
+        this.customLastYearOptions = customLastYearOptions;
+    }
+    getLastDayForGregorianLastDay(
+        lastDayOfGregorianYear: Date,
+        isoLastDayOfWeek: number,
+        retailCalendarYear: number,
+    ): Date {
+        const { calendarYear: startCalendarYear, yearEndDate: startYearEndDate, leapYearFrequency } = this.customLastYearOptions;
+        const yearDifference = retailCalendarYear - startCalendarYear;
+        let yearEndDate = new Date(startYearEndDate);
+        if (yearDifference > 0) {
+            // start at the startCalendarYear + 1, because we already have the end date for the startCalendarYear
+            for (let i = startCalendarYear + 1; i <= retailCalendarYear; i += 1) {
+                const isLeapYear = Math.abs(i - startCalendarYear) % leapYearFrequency === 0;
+                const numberOfWeeks = isLeapYear ? 53 : 52;
+                yearEndDate = addWeeksToDate(yearEndDate, numberOfWeeks);
+            }
+            return yearEndDate;
+        } else if (yearDifference < 0) {
+            for (let i = startCalendarYear; i > retailCalendarYear; i -= 1) {
+                const isLeapYear = Math.abs(i - startCalendarYear) % leapYearFrequency === 0;
+                const numberOfWeeks = isLeapYear ? 53 : 52;
+                yearEndDate = addWeeksToDate(yearEndDate, -numberOfWeeks);
+            }
+            return yearEndDate;
+        }
+
+        return yearEndDate;
+    }
+
+}

--- a/src/first_bow_of_first_month.ts
+++ b/src/first_bow_of_first_month.ts
@@ -5,6 +5,7 @@ export class FirstBOWOfFirstMonth implements LastDayStrategy {
   getLastDayForGregorianLastDay(
     lastDayOfGregorianYear: Date,
     lastDayOfIsoWeek: number,
+    _retailCalendarYear: number,
   ): Date {
     const firstDayOfIsoWeek = lastDayOfIsoWeek === 7 ? 1 : lastDayOfIsoWeek + 1
     // Go to the next month, i.e start month of next year

--- a/src/last_day_before_eom.ts
+++ b/src/last_day_before_eom.ts
@@ -5,6 +5,7 @@ export class LastDayBeforeEOMStrategy implements LastDayStrategy {
   getLastDayForGregorianLastDay(
     lastDayOfGregorianYear: Date,
     lastDayOfIsoWeek: number,
+    _retailCalendarYear: number,
   ): Date {
     let candidate = setIsoWeekDay(lastDayOfGregorianYear, lastDayOfIsoWeek)
 

--- a/src/last_day_before_eom_except_leap_year.ts
+++ b/src/last_day_before_eom_except_leap_year.ts
@@ -11,6 +11,7 @@ export class LastDayBeforeEOMExceptLeapYearStrategy implements LastDayStrategy {
   getLastDayForGregorianLastDay(
     lastDayOfGregorianYear: Date,
     lastDayOfIsoWeek: number,
+    retailCalendarYear: number,
   ): Date {
     const lastDayOfNextGregorianYear = endOfYear(
       addDaysToDate(lastDayOfGregorianYear, 1),
@@ -18,10 +19,12 @@ export class LastDayBeforeEOMExceptLeapYearStrategy implements LastDayStrategy {
     const lastDayOfThisYear = new LastDayBeforeEOMStrategy().getLastDayForGregorianLastDay(
       lastDayOfGregorianYear,
       lastDayOfIsoWeek,
+      retailCalendarYear,
     )
     const lastDayOfNextYear = new LastDayBeforeEOMStrategy().getLastDayForGregorianLastDay(
       lastDayOfNextGregorianYear,
       lastDayOfIsoWeek,
+        retailCalendarYear + 1,
     )
 
     if (getWeekDifference(lastDayOfNextYear, lastDayOfThisYear) === 53) {

--- a/src/last_day_before_eom_except_leap_year.ts
+++ b/src/last_day_before_eom_except_leap_year.ts
@@ -24,7 +24,7 @@ export class LastDayBeforeEOMExceptLeapYearStrategy implements LastDayStrategy {
     const lastDayOfNextYear = new LastDayBeforeEOMStrategy().getLastDayForGregorianLastDay(
       lastDayOfNextGregorianYear,
       lastDayOfIsoWeek,
-        retailCalendarYear + 1,
+      retailCalendarYear + 1,
     )
 
     if (getWeekDifference(lastDayOfNextYear, lastDayOfThisYear) === 53) {

--- a/src/last_day_nearest_eom.ts
+++ b/src/last_day_nearest_eom.ts
@@ -5,6 +5,7 @@ export class LastDayNearestEOMStrategy implements LastDayStrategy {
   getLastDayForGregorianLastDay(
     lastDayOfGregorianYear: Date,
     lastDayOfIsoWeek: number,
+    _retailCalendarYear: number,
   ): Date {
     const mutableLastDay = new Date(lastDayOfGregorianYear)
     // Generate 3 candidates which has the same day of week.

--- a/src/penultimate_day_of_week_nearest_eom.ts
+++ b/src/penultimate_day_of_week_nearest_eom.ts
@@ -11,6 +11,7 @@ export class PenultimateDayOfWeekNearestEOMStrategy implements LastDayStrategy {
   getLastDayForGregorianLastDay(
     lastDayOfGregorianYear: Date,
     lastDayOfIsoWeek: number,
+    retailCalendarYear: number,
   ): Date {
     // get penultimate day of ISO week by moving one day back
     const penultimateDayOfIsoWeek =
@@ -20,6 +21,7 @@ export class PenultimateDayOfWeekNearestEOMStrategy implements LastDayStrategy {
     const lastWeekOfYear = lastDayNearestEOMStrategy.getLastDayForGregorianLastDay(
       lastDayOfGregorianYear,
       penultimateDayOfIsoWeek,
+      retailCalendarYear,
     )
 
     // move the day one day forward to get the last day of the week

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -292,7 +292,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
         const { leapYear, leapYearEndDate,leapYearFrequency   } = this.options;
         if (leapYear === undefined || leapYearEndDate === undefined || leapYearFrequency === undefined) {
           throw new Error(
-            'CustomLeapYear week calculation requires customLeapYearOptions',
+            'CustomLeapYear week calculation requires leapYear, leapYearEndDate, and leapYearFrequency to be defined',
           )
         }
         return new CustomLeapYearStrategy(leapYear, leapYearEndDate, leapYearFrequency)

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -289,15 +289,14 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       case WeekCalculation.PenultimateDayOfWeekNearestEOM:
         return new PenultimateDayOfWeekNearestEOMStrategy()
       case WeekCalculation.CustomLeapYear: {
-        const customLeapYearOptions = this.options.customLeapYearOptions
-        if (!customLeapYearOptions) {
+        const { leapYear, leapYearEndDate,leapYearFrequency   } = this.options;
+        if (leapYear === undefined || leapYearEndDate === undefined || leapYearFrequency === undefined) {
           throw new Error(
             'CustomLeapYear week calculation requires customLeapYearOptions',
           )
         }
-        return new CustomLeapYearStrategy(customLeapYearOptions)
+        return new CustomLeapYearStrategy(leapYear, leapYearEndDate, leapYearFrequency)
       }
-
     }
   }
 

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -32,7 +32,7 @@ import {
   memoize,
 } from './utils/memoization'
 import { PenultimateDayOfWeekNearestEOMStrategy } from './penultimate_day_of_week_nearest_eom'
-import {CustomLeapYearStrategy} from "./custom_leap_year";
+import { CustomLeapYearStrategy } from './custom_leap_year'
 
 const buildRetailCalendarFactory = memoize(
   (retailCalendarOptions: RetailCalendarOptions, year: number) =>
@@ -60,7 +60,10 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     this.calendarYear = this.getAdjustedGregorianYear(year)
     this.addLeapWeekToMonth = this.options.addLeapWeekToMonth ?? -1
     this.numberOfWeeks = this.calculateNumberOfWeeks()
-    this.lastDayOfYear = this.calculateLastDayOfYear(this.calendarYear, this.year)
+    this.lastDayOfYear = this.calculateLastDayOfYear(
+      this.calendarYear,
+      this.year,
+    )
     this.firstDayOfYear = startOfDay(
       addDaysToDate(addWeeksToDate(this.lastDayOfYear, -this.numberOfWeeks), 1),
     )
@@ -289,13 +292,21 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
       case WeekCalculation.PenultimateDayOfWeekNearestEOM:
         return new PenultimateDayOfWeekNearestEOMStrategy()
       case WeekCalculation.CustomLeapYear: {
-        const { leapYear, leapYearEndDate,leapYearFrequency   } = this.options;
-        if (leapYear === undefined || leapYearEndDate === undefined || leapYearFrequency === undefined) {
+        const { leapYear, leapYearEndDate, leapYearFrequency } = this.options
+        if (
+          leapYear === undefined ||
+          leapYearEndDate === undefined ||
+          leapYearFrequency === undefined
+        ) {
           throw new Error(
             'CustomLeapYear week calculation requires leapYear, leapYearEndDate, and leapYearFrequency to be defined',
           )
         }
-        return new CustomLeapYearStrategy(leapYear, leapYearEndDate, leapYearFrequency)
+        return new CustomLeapYearStrategy(
+          leapYear,
+          leapYearEndDate,
+          leapYearFrequency,
+        )
       }
     }
   }

--- a/src/retail_calendar.ts
+++ b/src/retail_calendar.ts
@@ -32,6 +32,7 @@ import {
   memoize,
 } from './utils/memoization'
 import { PenultimateDayOfWeekNearestEOMStrategy } from './penultimate_day_of_week_nearest_eom'
+import {CustomLeapYearStrategy} from "./custom_leap_year";
 
 const buildRetailCalendarFactory = memoize(
   (retailCalendarOptions: RetailCalendarOptions, year: number) =>
@@ -59,7 +60,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     this.calendarYear = this.getAdjustedGregorianYear(year)
     this.addLeapWeekToMonth = this.options.addLeapWeekToMonth ?? -1
     this.numberOfWeeks = this.calculateNumberOfWeeks()
-    this.lastDayOfYear = this.calculateLastDayOfYear(this.calendarYear)
+    this.lastDayOfYear = this.calculateLastDayOfYear(this.calendarYear, this.year)
     this.firstDayOfYear = startOfDay(
       addDaysToDate(addWeeksToDate(this.lastDayOfYear, -this.numberOfWeeks), 1),
     )
@@ -243,7 +244,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     return weekDistribution
   }
 
-  calculateLastDayOfYear(year: number): Date {
+  calculateLastDayOfYear(year: number, retailCalendarYear: number): Date {
     const firstDayOfLastMonthOfYear = newSafeDate()
     firstDayOfLastMonthOfYear.setFullYear(year)
     firstDayOfLastMonthOfYear.setMonth(this.options.lastMonthOfYear, 1)
@@ -256,6 +257,7 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     return weekCalculation.getLastDayForGregorianLastDay(
       lastDayOfYear,
       lastIsoWeekDay,
+      retailCalendarYear,
     )
   }
 
@@ -263,10 +265,10 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
     // Make sure we get whole day difference
     // by measuring from the end of current year to start of last year
     const lastDayOfYear = endOfDay(
-      this.calculateLastDayOfYear(this.calendarYear),
+      this.calculateLastDayOfYear(this.calendarYear, this.year),
     )
     const lastDayOfLastYear = startOfDay(
-      this.calculateLastDayOfYear(this.calendarYear - 1),
+      this.calculateLastDayOfYear(this.calendarYear - 1, this.year - 1),
     )
     const numWeeks = getWeekDifference(lastDayOfYear, lastDayOfLastYear)
     return numWeeks
@@ -286,6 +288,16 @@ export const RetailCalendarFactory: RetailCalendarConstructor = class Calendar
         return new FirstBOWOfFirstMonth()
       case WeekCalculation.PenultimateDayOfWeekNearestEOM:
         return new PenultimateDayOfWeekNearestEOMStrategy()
+      case WeekCalculation.CustomLeapYear: {
+        const customLeapYearOptions = this.options.customLeapYearOptions
+        if (!customLeapYearOptions) {
+          throw new Error(
+            'CustomLeapYear week calculation requires customLeapYearOptions',
+          )
+        }
+        return new CustomLeapYearStrategy(customLeapYearOptions)
+      }
+
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,13 +47,11 @@ export interface RetailCalendarOptions {
    */
   addLeapWeekToMonth?: number
   beginningMonthIndex?: number
-  customLeapYearOptions?: CustomLeapYearOptions
-}
 
-export type CustomLeapYearOptions = {
-    calendarYear: number
-    yearEndDate: string // In the format of "YYYY-MM-DD"
-    leapYearFrequency: number // In years
+  // Leap Year Options
+  leapYear?: number
+  leapYearEndDate?: string // In the format of "YYYY-MM-DD"
+  leapYearFrequency?: number // In years
 }
 
 export const NRFCalendarOptions: RetailCalendarOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,11 @@ export enum WeekCalculation {
   LastDayNearestEOM,
   FirstBOWOfFirstMonth,
   PenultimateDayOfWeekNearestEOM,
+  CustomLeapYear,
 }
 
+// Adding new fields to this type will break memoization
+// Make sure that you adjust the memoization logic in src/utils/memoization.ts#stringifyCalendarOptions
 export interface RetailCalendarOptions {
   weekGrouping: WeekGrouping
   lastDayOfWeek: LastDayOfWeek
@@ -44,6 +47,13 @@ export interface RetailCalendarOptions {
    */
   addLeapWeekToMonth?: number
   beginningMonthIndex?: number
+  customLeapYearOptions?: CustomLeapYearOptions
+}
+
+export type CustomLeapYearOptions = {
+    calendarYear: number
+    yearEndDate: string // In the format of "YYYY-MM-DD"
+    leapYearFrequency: number // In years
 }
 
 export const NRFCalendarOptions: RetailCalendarOptions = {
@@ -106,6 +116,7 @@ export interface LastDayStrategy {
   getLastDayForGregorianLastDay(
     lastDayOfGregorianYear: Date,
     isoLastDayOfWeek: number,
+    retailCalendarYear: number,
   ): Date
 }
 

--- a/src/utils/memoization.ts
+++ b/src/utils/memoization.ts
@@ -1,4 +1,4 @@
-import {CustomLeapYearOptions, RetailCalendarOptions} from '../types'
+import { RetailCalendarOptions} from '../types'
 
 export function memoize<T extends (...args: any) => any>(
   func: T,
@@ -29,7 +29,8 @@ export function createMemoizationKeyFromCalendarOptionsAndYear(
 function stringifyCalendarOptions(
   retailCalendarOptions: RetailCalendarOptions,
 ) {
-  const { weekGrouping, lastDayOfWeek, lastMonthOfYear, weekCalculation, addLeapWeekToMonth, beginningMonthIndex, customLeapYearOptions } = retailCalendarOptions
-  return `1:${weekGrouping}-2:${lastDayOfWeek}-3:${lastMonthOfYear}-4:${weekCalculation}-5:${addLeapWeekToMonth}-6:${beginningMonthIndex}-7:${customLeapYearOptions?.calendarYear}-8:${customLeapYearOptions?.yearEndDate}-9:${customLeapYearOptions?.leapYearFrequency}`
+  return Object.entries(retailCalendarOptions)
+      .map((e) => e.join(':'))
+      .join('-')
 }
 

--- a/src/utils/memoization.ts
+++ b/src/utils/memoization.ts
@@ -1,4 +1,4 @@
-import { RetailCalendarOptions} from '../types'
+import { RetailCalendarOptions } from '../types'
 
 export function memoize<T extends (...args: any) => any>(
   func: T,
@@ -30,7 +30,6 @@ function stringifyCalendarOptions(
   retailCalendarOptions: RetailCalendarOptions,
 ) {
   return Object.entries(retailCalendarOptions)
-      .map((e) => e.join(':'))
-      .join('-')
+    .map((e) => e.join(':'))
+    .join('-')
 }
-

--- a/src/utils/memoization.ts
+++ b/src/utils/memoization.ts
@@ -1,4 +1,4 @@
-import { RetailCalendarOptions } from '../types'
+import {CustomLeapYearOptions, RetailCalendarOptions} from '../types'
 
 export function memoize<T extends (...args: any) => any>(
   func: T,
@@ -29,7 +29,7 @@ export function createMemoizationKeyFromCalendarOptionsAndYear(
 function stringifyCalendarOptions(
   retailCalendarOptions: RetailCalendarOptions,
 ) {
-  return Object.entries(retailCalendarOptions)
-    .map((e) => e.join(':'))
-    .join('-')
+  const { weekGrouping, lastDayOfWeek, lastMonthOfYear, weekCalculation, addLeapWeekToMonth, beginningMonthIndex, customLeapYearOptions } = retailCalendarOptions
+  return `1:${weekGrouping}-2:${lastDayOfWeek}-3:${lastMonthOfYear}-4:${weekCalculation}-5:${addLeapWeekToMonth}-6:${beginningMonthIndex}-7:${customLeapYearOptions?.calendarYear}-8:${customLeapYearOptions?.yearEndDate}-9:${customLeapYearOptions?.leapYearFrequency}`
 }
+


### PR DESCRIPTION
* Adds a new option RetailCalendarOption.customLeapYearOptions. Calendar now can be configured to have a specific leap year with a specific end date and leap year frequency.